### PR TITLE
working locally

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,9 +11,9 @@ import Config
 # Set development-specific Supabase configuration
 # This overrides the main supabase.exs config for development
 config :eventasaurus, :supabase,
-  url: "http://localhost:54321",  # Local Supabase URL
+  url: "http://127.0.0.1:54321",  # Local Supabase URL
   api_key: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0",  # Default anon key for local Supabase
-  database_url: "postgresql://postgres:postgres@localhost:54321/postgres",  # Local DB
+  database_url: "postgresql://postgres:postgres@127.0.0.1:54322/postgres",  # Local DB - NOTE: PostgreSQL runs on port 54322
   auth: %{
     site_url: "http://localhost:4000",
     additional_redirect_urls: ["http://localhost:4000/auth/callback"],

--- a/config/dev.secret.exs
+++ b/config/dev.secret.exs
@@ -1,11 +1,12 @@
 import Config
 
-# Configure the database
+# Configure the database to use Supabase's PostgreSQL instance
 config :eventasaurus, EventasaurusApp.Repo,
   username: "postgres",
   password: "postgres",
-  hostname: "localhost",
-  database: "eventasaurus_dev",
+  hostname: "127.0.0.1",
+  port: 54322,
+  database: "postgres",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10

--- a/lib/eventasaurus/application.ex
+++ b/lib/eventasaurus/application.ex
@@ -28,6 +28,15 @@ defmodule Eventasaurus.Application do
     api_key = System.get_env("GOOGLE_MAPS_API_KEY")
     IO.puts("DEBUG - Google Maps API key loaded: #{if api_key, do: "YES", else: "NO"}")
 
+    # Debug Supabase connection
+    db_config = Application.get_env(:eventasaurus, EventasaurusApp.Repo)
+    IO.puts("DEBUG - Database Connection Info:")
+    IO.puts("  Hostname: #{db_config[:hostname]}")
+    IO.puts("  Port: #{db_config[:port]}")
+    IO.puts("  Database: #{db_config[:database]}")
+    IO.puts("  Username: #{db_config[:username]}")
+    IO.puts("DEBUG - Using Supabase PostgreSQL: #{db_config[:port] == 54322}")
+
     children = [
       EventasaurusWeb.Telemetry,
       # Start Ecto repository (used alongside Supabase)


### PR DESCRIPTION
### TL;DR

Updated database configuration to properly connect to Supabase's local PostgreSQL instance.

### What changed?

- Changed Supabase URL from `localhost` to `127.0.0.1` for more reliable connections
- Updated PostgreSQL port from 54321 to 54322 in database connection strings
- Added debug logging to display database connection information during startup
- Modified database configuration in `dev.secret.exs` to match Supabase's PostgreSQL settings

### How to test?

1. Start your local Supabase instance
2. Launch the application in development mode
3. Check the console logs to verify the database connection is using port 54322
4. Confirm the application connects to the database successfully
5. Verify that database operations work as expected

### Why make this change?

Supabase runs PostgreSQL on port 54322 rather than the default 54321 (which is used for the API). This change ensures our application connects to the correct port for database operations. Using `127.0.0.1` instead of `localhost` also provides more consistent connection behavior across different environments.