### PR TITLE
fix warnings

### DIFF
--- a/lib/eventasaurus_web/live/event_live/new.ex
+++ b/lib/eventasaurus_web/live/event_live/new.ex
@@ -70,7 +70,7 @@ defmodule EventasaurusWeb.EventLive.New do
       {:ok, user} ->
         # Create the event with the user struct
         case Events.create_event_with_organizer(event_params, user) do
-          {:ok, event} ->
+          {:ok, _event} ->
             {:noreply,
              socket
              |> put_flash(:info, "Event created successfully")


### PR DESCRIPTION
### TL;DR

Fixed unused variable warning by replacing `event` with `_event` in the event creation success pattern match.

### What changed?

Modified the pattern match in `new.ex` to use `_event` instead of `event` since the variable was not being used in the success case of the `create_event_with_organizer` function. This change prevents compiler warnings about unused variables.

### How to test?

1. Verify that the event creation flow still works correctly
2. Confirm that no compiler warnings are generated for unused variables
3. Create a new event and ensure it redirects properly to the index page

### Why make this change?

This change improves code quality by eliminating an unused variable warning. Using the underscore prefix for unused variables is a common Elixir convention that explicitly indicates a variable is intentionally not used, which helps maintain clean code and prevents compiler warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of event creation results with no visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->