### PR TITLE
fixes

### DIFF
--- a/lib/eventasaurus_web/helpers/timezone_helpers.ex
+++ b/lib/eventasaurus_web/helpers/timezone_helpers.ex
@@ -140,22 +140,20 @@ defmodule EventasaurusWeb.TimezoneHelpers do
   defp asia_pacific_options do
     [
       "Asia/Tokyo",
-      "Asia/Shanghai",
+      "Asia/Shanghai", # Also Beijing
       "Asia/Singapore",
       "Asia/Seoul",
       "Australia/Sydney",
       "Australia/Melbourne",
       "Pacific/Auckland",
       "Asia/Dubai",
-      "Asia/Kolkata",
-      "Asia/Kolkata", # New Delhi
+      "Asia/Kolkata", # Also New Delhi
       "Asia/Bangkok",
       "Asia/Jakarta",
       "Asia/Kuala_Lumpur",
       "Asia/Manila",
       "Asia/Taipei",
       "Asia/Hong_Kong",
-      "Asia/Shanghai", # Beijing
       "Asia/Karachi"
     ]
     |> Enum.map(fn tz ->


### PR DESCRIPTION
### TL;DR

Removed duplicate timezone entries and improved comments in the Asia/Pacific timezone options list.

### What changed?

- Removed the duplicate entry for `"Asia/Shanghai"` (Beijing) that appeared at the bottom of the list
- Removed the duplicate entry for `"Asia/Kolkata"`
- Improved the comments format for timezone aliases:
  - Changed `"Asia/Kolkata", # New Delhi` to `"Asia/Kolkata", # Also New Delhi`
  - Added `# Also Beijing` comment to the first occurrence of `"Asia/Shanghai"`

### How to test?

1. Navigate to any page that displays timezone selection options
2. Verify that Asia/Shanghai and Asia/Kolkata each appear only once in the dropdown
3. Confirm that the timezone selection functionality works correctly

### Why make this change?

Having duplicate timezone entries in the dropdown list could cause confusion for users and potentially lead to unexpected behavior. This change ensures each timezone appears only once while maintaining clear comments about city aliases.