### PR TITLE
first steps for image modal

### DIFF
--- a/lib/eventasaurus_app/events/event.ex
+++ b/lib/eventasaurus_app/events/event.ex
@@ -13,6 +13,7 @@ defmodule EventasaurusApp.Events.Event do
     field :visibility, Ecto.Enum, values: [:public, :private], default: :public
     field :slug, :string
     field :cover_image_url, :string
+    field :unsplash_data, :map
 
     belongs_to :venue, EventasaurusApp.Venues.Venue
 
@@ -26,7 +27,7 @@ defmodule EventasaurusApp.Events.Event do
   def changeset(event, attrs) do
     event
     |> cast(attrs, [:title, :tagline, :description, :start_at, :ends_at, :timezone,
-                   :visibility, :slug, :cover_image_url, :venue_id])
+                   :visibility, :slug, :cover_image_url, :venue_id, :unsplash_data])
     |> validate_required([:title, :start_at, :timezone, :visibility])
     |> validate_length(:title, min: 3, max: 100)
     |> validate_length(:tagline, max: 255)

--- a/lib/eventasaurus_web/components/event_components.ex
+++ b/lib/eventasaurus_web/components/event_components.ex
@@ -2,6 +2,8 @@ defmodule EventasaurusWeb.EventComponents do
   use Phoenix.Component
   import EventasaurusWeb.CoreComponents
   alias EventasaurusWeb.TimezoneHelpers
+  import Phoenix.HTML.Form
+  alias Phoenix.LiveView.JS
 
   @doc """
   Renders a time select dropdown with 30-minute increments.
@@ -169,11 +171,66 @@ defmodule EventasaurusWeb.EventComponents do
   attr :cancel_path, :string, default: nil, doc: "path to redirect on cancel (edit only)"
   attr :action, :atom, required: true, values: [:new, :edit], doc: "whether this is a new or edit form"
   attr :show_all_timezones, :boolean, default: false, doc: "whether to show all timezones"
+  attr :cover_image_url, :string, default: nil, doc: "the cover image URL"
+  attr :unsplash_data, :map, default: nil, doc: "unsplash data for attribution"
+  attr :on_image_click, :string, default: nil, doc: "event name to trigger when clicking on the image picker"
 
   def event_form(assigns) do
     ~H"""
     <.form :let={f} for={@for} phx-change="validate" phx-submit="submit" phx-hook="EventFormHook">
       <div class="bg-white shadow-md rounded-lg p-6 mb-6 border border-gray-200">
+        <!-- Cover Image -->
+        <div class="mb-8">
+          <h2 class="text-xl font-bold mb-4">Cover Image</h2>
+
+          <div class="space-y-4">
+            <%= if f[:cover_image_url].value do %>
+              <div class="mb-4">
+                <div class="relative rounded-lg overflow-hidden h-48 bg-gray-100">
+                  <img src={f[:cover_image_url].value} alt="Cover image" class="w-full h-full object-cover" />
+
+                  <div class="absolute inset-0 flex items-center justify-center bg-black bg-opacity-0 hover:bg-opacity-30 transition-all">
+                    <button
+                      type="button"
+                      phx-click={JS.push(@on_image_click)}
+                      class="bg-white text-gray-800 px-4 py-2 rounded-lg shadow-sm opacity-0 hover:opacity-100 transition-opacity transform translate-y-2 hover:translate-y-0"
+                    >
+                      Change Image
+                    </button>
+                  </div>
+                </div>
+
+                <%= if @unsplash_data do %>
+                  <div class="mt-2 text-xs text-gray-500">
+                    Photo by
+                    <a href={@unsplash_data["photographer_url"]} target="_blank" class="underline">
+                      <%= @unsplash_data["photographer_name"] %>
+                    </a>
+                    on <a href="https://unsplash.com" target="_blank" class="underline">Unsplash</a>
+                  </div>
+                <% end %>
+              </div>
+            <% else %>
+              <div class="mb-4">
+                <button
+                  type="button"
+                  phx-click={JS.push(@on_image_click)}
+                  class="w-full h-48 flex flex-col items-center justify-center border-2 border-dashed border-gray-300 rounded-lg hover:border-gray-400 transition-colors bg-gray-50"
+                >
+                  <svg class="w-12 h-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"></path>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                  </svg>
+                  <p class="mt-2 text-sm text-gray-600">Click to add a cover image</p>
+                </button>
+              </div>
+            <% end %>
+
+            <%= hidden_input f, :cover_image_url %>
+            <%= hidden_input f, :unsplash_data %>
+          </div>
+        </div>
+
         <!-- Basic Information -->
         <div class="mb-8">
           <h2 class="text-xl font-bold mb-4">Basic Information</h2>
@@ -337,7 +394,7 @@ defmodule EventasaurusWeb.EventComponents do
         <div class="mb-8">
           <h2 class="text-xl font-bold mb-4">Details</h2>
           <div class="space-y-4">
-            <.input field={f[:cover_image_url]} type="text" label="Cover Image URL" />
+            <.input field={f[:cover_image_url]} type="text" label="Cover Image URL" id="details_cover_image_url" />
           </div>
         </div>
 

--- a/lib/eventasaurus_web/controllers/event_html/show.html.heex
+++ b/lib/eventasaurus_web/controllers/event_html/show.html.heex
@@ -33,7 +33,19 @@
 <div class="max-w-3xl mx-auto mt-8">
   <div class="bg-white shadow-md rounded-lg overflow-hidden">
     <%= if @event.cover_image_url && @event.cover_image_url != "" do %>
-      <img src={@event.cover_image_url} alt={@event.title} class="w-full h-48 object-cover object-center" />
+      <div class="relative">
+        <img src={@event.cover_image_url} alt={@event.title} class="w-full h-60 sm:h-72 object-cover object-center" />
+        <%= if @event.unsplash_data do %>
+          <div class="absolute bottom-0 right-0 bg-black bg-opacity-50 text-white text-xs p-2 rounded-tl">
+            Photo by 
+            <a href={@event.unsplash_data["photographer_url"]} target="_blank" class="underline hover:text-gray-200">
+              <%= @event.unsplash_data["photographer_name"] %>
+            </a> 
+            on 
+            <a href="https://unsplash.com" target="_blank" class="underline hover:text-gray-200">Unsplash</a>
+          </div>
+        <% end %>
+      </div>
     <% else %>
       <div class="w-full h-48 bg-gray-300 flex items-center justify-center">
         <p class="text-gray-600">No Cover Image</p>

--- a/lib/eventasaurus_web/live/components/image_picker_component.ex
+++ b/lib/eventasaurus_web/live/components/image_picker_component.ex
@@ -1,0 +1,255 @@
+defmodule EventasaurusWeb.Live.Components.ImagePickerComponent do
+  use EventasaurusWeb, :live_component
+
+  alias EventasaurusWeb.Services.UnsplashService
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+      socket
+      |> assign(:tab, "unsplash")
+      |> assign(:search_query, "")
+      |> assign(:search_results, [])
+      |> assign(:loading, false)
+      |> assign(:error, nil)
+      |> assign(:selected_image, nil)
+      |> assign(:page, 1)
+      |> assign(:per_page, 20)
+    }
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok,
+      socket
+      |> assign(assigns)
+      |> assign(:tab, Map.get(assigns, :tab, "unsplash"))
+    }
+  end
+
+  @impl true
+  def handle_event("change-tab", %{"tab" => tab}, socket) do
+    {:noreply, assign(socket, :tab, tab)}
+  end
+
+  @impl true
+  def handle_event("search", %{"search_query" => query}, socket) when query == "" do
+    {:noreply,
+      socket
+      |> assign(:search_query, "")
+      |> assign(:search_results, [])
+      |> assign(:error, nil)
+    }
+  end
+
+  @impl true
+  def handle_event("search", %{"search_query" => query}, socket) do
+    {:noreply,
+      socket
+      |> assign(:search_query, query)
+      |> assign(:loading, true)
+      |> assign(:page, 1)
+      |> do_search()
+    }
+  end
+
+  @impl true
+  def handle_event("load-more", _, socket) do
+    {:noreply,
+      socket
+      |> assign(:page, socket.assigns.page + 1)
+      |> assign(:loading, true)
+      |> do_search()
+    }
+  end
+
+  @impl true
+  def handle_event("select-image", %{"id" => id}, socket) do
+    case Enum.find(socket.assigns.search_results, &(&1.id == id)) do
+      nil ->
+        {:noreply, socket}
+
+      image ->
+        selected_image = %{
+          id: image.id,
+          description: image.description,
+          url: image.urls.regular,
+          user: %{
+            name: image.user.name,
+            username: image.user.username,
+            profile_url: image.user.profile_url
+          },
+          download_location: image.download_location
+        }
+
+        # Track the download as per Unsplash API requirements
+        UnsplashService.track_download(image.download_location)
+
+        # Create the unsplash_data map to be stored in the database
+        unsplash_data = %{
+          "photo_id" => image.id,
+          "url" => image.urls.regular,
+          "full_url" => image.urls.full,
+          "raw_url" => image.urls.raw,
+          "photographer_name" => image.user.name,
+          "photographer_username" => image.user.username,
+          "photographer_url" => image.user.profile_url,
+          "download_location" => image.download_location
+        }
+
+        # Send the selected image back to the parent
+        send(self(), {:image_selected, %{
+          cover_image_url: image.urls.regular,
+          unsplash_data: unsplash_data
+        }})
+
+        # Also send close event to parent
+        send(self(), {:close_image_picker, nil})
+
+        {:noreply, assign(socket, :selected_image, selected_image)}
+    end
+  end
+
+  defp do_search(socket) do
+    case UnsplashService.search_photos(
+      socket.assigns.search_query,
+      socket.assigns.page,
+      socket.assigns.per_page
+    ) do
+      {:ok, results} ->
+        # If this is page 1, replace results, otherwise append
+        updated_results =
+          if socket.assigns.page == 1 do
+            results
+          else
+            socket.assigns.search_results ++ results
+          end
+
+        socket
+        |> assign(:search_results, updated_results)
+        |> assign(:loading, false)
+        |> assign(:error, nil)
+
+      {:error, reason} ->
+        socket
+        |> assign(:loading, false)
+        |> assign(:error, "Error searching Unsplash: #{reason}")
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={"image-picker-component-#{@id}"} class="w-full">
+      <!-- Tabs -->
+      <div class="border-b border-gray-200 mb-6">
+        <nav class="-mb-px flex" aria-label="Tabs">
+          <button
+            phx-click="change-tab"
+            phx-value-tab="unsplash"
+            phx-target={@myself}
+            class={[
+              "px-4 py-2 text-sm font-medium border-b-2",
+              @tab == "unsplash" && "border-indigo-500 text-indigo-600" || "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            ]}
+          >
+            Search Unsplash
+          </button>
+        </nav>
+      </div>
+
+      <!-- Unsplash Search Tab -->
+      <div class={@tab == "unsplash" && "block" || "hidden"}>
+        <form phx-submit="search" phx-target={@myself} class="mb-6">
+          <div class="flex">
+            <div class="relative flex-grow">
+              <input
+                type="text"
+                name="search_query"
+                id={"search-query-#{@id}"}
+                value={@search_query}
+                class="w-full px-4 py-2 border border-gray-300 rounded-l-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
+                placeholder="Search for images..."
+                aria-label="Search for images"
+              />
+            </div>
+            <button
+              type="submit"
+              class="px-4 py-2 bg-indigo-600 border border-transparent rounded-r-md shadow-sm text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              Search
+            </button>
+          </div>
+        </form>
+
+        <%= if @loading and @page == 1 do %>
+          <div class="flex justify-center my-12">
+            <div class="w-12 h-12 border-t-2 border-b-2 border-indigo-500 rounded-full animate-spin"></div>
+          </div>
+        <% end %>
+
+        <%= if @error do %>
+          <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded relative mb-6" role="alert">
+            <span class="block sm:inline"><%= @error %></span>
+          </div>
+        <% end %>
+
+        <%= if length(@search_results) > 0 do %>
+          <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mb-6">
+            <%= for image <- @search_results do %>
+              <div
+                phx-click="select-image"
+                phx-value-id={image.id}
+                phx-target={@myself}
+                class="relative group cursor-pointer overflow-hidden rounded-md"
+              >
+                <img
+                  src={image.urls.small}
+                  alt={image.description}
+                  class="w-full h-40 object-cover transform transition-transform duration-300 group-hover:scale-110"
+                />
+                <div class="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-opacity duration-300"></div>
+                <div class="absolute bottom-0 left-0 right-0 p-2 text-white bg-gradient-to-t from-black to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                  <p class="text-xs truncate">Photo by <%= image.user.name %></p>
+                </div>
+              </div>
+            <% end %>
+          </div>
+
+          <%= if @loading and @page > 1 do %>
+            <div class="flex justify-center my-6">
+              <div class="w-8 h-8 border-t-2 border-b-2 border-indigo-500 rounded-full animate-spin"></div>
+            </div>
+          <% else %>
+            <div class="flex justify-center mb-6">
+              <button
+                phx-click="load-more"
+                phx-target={@myself}
+                class="px-4 py-2 bg-white border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              >
+                Load More
+              </button>
+            </div>
+          <% end %>
+        <% else %>
+          <%= if @search_query == "" do %>
+            <div class="text-center py-12 text-gray-500">
+              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"></path>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"></path>
+              </svg>
+              <p class="mt-2 text-sm">Search for images on Unsplash</p>
+            </div>
+          <% else %>
+            <%= if not @loading do %>
+              <div class="text-center py-12 text-gray-500">
+                <p class="mt-2 text-sm">No results found for "<%= @search_query %>"</p>
+              </div>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/eventasaurus_web/live/event_live/edit.html.heex
+++ b/lib/eventasaurus_web/live/event_live/edit.html.heex
@@ -16,5 +16,44 @@
     cancel_path={~p"/events/#{@event}"}
     action={:edit}
     show_all_timezones={@show_all_timezones}
+    cover_image_url={@cover_image_url}
+    unsplash_data={@unsplash_data}
+    on_image_click="open_image_picker"
   />
-</div> 
+</div>
+
+<%= if @show_image_picker do %>
+  <div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 overflow-auto">
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-auto relative">
+      <div class="sticky top-0 bg-white z-10 px-6 py-4 border-b flex justify-between items-center">
+        <h2 class="text-xl font-bold">Choose a Cover Image</h2>
+        <button 
+          type="button" 
+          phx-click="close_image_picker"
+          class="text-gray-500 hover:text-gray-700"
+        >
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+          </svg>
+        </button>
+      </div>
+      
+      <div class="p-6">
+        <.live_component
+          module={EventasaurusWeb.Live.Components.ImagePickerComponent}
+          id="image-picker"
+        />
+      </div>
+      
+      <div class="sticky bottom-0 bg-white border-t px-6 py-4 flex justify-end">
+        <button
+          type="button"
+          phx-click="close_image_picker"
+          class="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+<% end %> 

--- a/lib/eventasaurus_web/live/event_live/new.html.heex
+++ b/lib/eventasaurus_web/live/event_live/new.html.heex
@@ -14,5 +14,44 @@
     submit_label="Create Event"
     action={:new}
     show_all_timezones={@show_all_timezones}
+    cover_image_url={@cover_image_url}
+    unsplash_data={@unsplash_data}
+    on_image_click="open_image_picker"
   />
-</div> 
+</div>
+
+<%= if @show_image_picker do %>
+  <div class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 overflow-auto">
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-auto relative">
+      <div class="sticky top-0 bg-white z-10 px-6 py-4 border-b flex justify-between items-center">
+        <h2 class="text-xl font-bold">Choose a Cover Image</h2>
+        <button 
+          type="button" 
+          phx-click="close_image_picker"
+          class="text-gray-500 hover:text-gray-700"
+        >
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+          </svg>
+        </button>
+      </div>
+      
+      <div class="p-6">
+        <.live_component
+          module={EventasaurusWeb.Live.Components.ImagePickerComponent}
+          id="image-picker"
+        />
+      </div>
+      
+      <div class="sticky bottom-0 bg-white border-t px-6 py-4 flex justify-end">
+        <button
+          type="button"
+          phx-click="close_image_picker"
+          class="px-4 py-2 bg-gray-200 text-gray-800 rounded-md hover:bg-gray-300"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+<% end %> 

--- a/lib/eventasaurus_web/services/unsplash_service.ex
+++ b/lib/eventasaurus_web/services/unsplash_service.ex
@@ -1,0 +1,97 @@
+defmodule EventasaurusWeb.Services.UnsplashService do
+  @moduledoc """
+  Service for interacting with the Unsplash API.
+  """
+
+  @doc """
+  Search for photos on Unsplash.
+  Returns a list of photos that match the search query.
+  """
+  def search_photos(query, page \\ 1, per_page \\ 20) do
+    case get("/search/photos", %{query: query, page: page, per_page: per_page}) do
+      {:ok, %{"results" => results}} ->
+        processed_results =
+          results
+          |> Enum.map(fn photo ->
+            %{
+              id: photo["id"],
+              description: photo["description"] || photo["alt_description"] || "Unsplash photo",
+              urls: %{
+                raw: photo["urls"]["raw"],
+                full: photo["urls"]["full"],
+                regular: photo["urls"]["regular"],
+                small: photo["urls"]["small"],
+                thumb: photo["urls"]["thumb"]
+              },
+              user: %{
+                name: photo["user"]["name"],
+                username: photo["user"]["username"],
+                profile_url: photo["user"]["links"]["html"]
+              },
+              download_location: photo["links"]["download_location"]
+            }
+          end)
+
+        {:ok, processed_results}
+
+      {:ok, response} ->
+        {:error, "Unexpected response format: #{inspect(response)}"}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Triggers a download event for the given photo ID.
+  This is required by Unsplash API terms whenever a photo is downloaded or used.
+  """
+  def track_download(download_location) do
+    case get(download_location, %{}) do
+      {:ok, _response} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Private helper functions
+
+  defp get(path, params) do
+    url = build_url(path, params)
+
+    headers = [
+      {"Authorization", "Client-ID #{access_key()}"},
+      {"Accept-Version", "v1"}
+    ]
+
+    case HTTPoison.get(url, headers) do
+      {:ok, %HTTPoison.Response{status_code: code, body: body}} when code in 200..299 ->
+        {:ok, Jason.decode!(body)}
+
+      {:ok, %HTTPoison.Response{status_code: code, body: body}} ->
+        {:error, "Unsplash API error: #{code}, #{body}"}
+
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, "HTTP error: #{inspect(reason)}"}
+    end
+  end
+
+  defp build_url(path, params) do
+    base_url = "https://api.unsplash.com"
+
+    # Remove the leading slash if present
+    path = if String.starts_with?(path, "/"), do: String.slice(path, 1..-1//1), else: path
+
+    # Build the query string
+    query_string =
+      params
+      |> Enum.map(fn {key, value} -> "#{key}=#{URI.encode_www_form(to_string(value))}" end)
+      |> Enum.join("&")
+
+    # Combine base URL, path and query string
+    if query_string != "", do: "#{base_url}/#{path}?#{query_string}", else: "#{base_url}/#{path}"
+  end
+
+  defp access_key do
+    System.get_env("UNSPLASH_ACCESS_KEY") || raise "UNSPLASH_ACCESS_KEY is not set in environment variables"
+  end
+end

--- a/priv/repo/migrations/20250508104758_add_unsplash_data_to_events.exs
+++ b/priv/repo/migrations/20250508104758_add_unsplash_data_to_events.exs
@@ -1,0 +1,9 @@
+defmodule EventasaurusApp.Repo.Migrations.AddUnsplashDataToEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:events) do
+      add :unsplash_data, :map
+    end
+  end
+end

--- a/priv/static/assets/app.css
+++ b/priv/static/assets/app.css
@@ -786,6 +786,10 @@ select {
   position: relative;
 }
 
+.sticky {
+  position: sticky;
+}
+
 .inset-0 {
   inset: 0px;
 }
@@ -808,6 +812,10 @@ select {
   right: -1rem;
 }
 
+.bottom-0 {
+  bottom: 0px;
+}
+
 .left-0 {
   left: 0px;
 }
@@ -828,6 +836,10 @@ select {
   right: 1.25rem;
 }
 
+.top-0 {
+  top: 0px;
+}
+
 .top-1 {
   top: 0.25rem;
 }
@@ -838,6 +850,10 @@ select {
 
 .top-6 {
   top: 1.5rem;
+}
+
+.z-10 {
+  z-index: 10;
 }
 
 .z-50 {
@@ -856,6 +872,20 @@ select {
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
+}
+
+.my-12 {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
+
+.my-6 {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.-mb-px {
+  margin-bottom: -1px;
 }
 
 .mb-1 {
@@ -978,12 +1008,20 @@ select {
   display: none;
 }
 
+.h-12 {
+  height: 3rem;
+}
+
 .h-3 {
   height: 0.75rem;
 }
 
 .h-4 {
   height: 1rem;
+}
+
+.h-40 {
+  height: 10rem;
 }
 
 .h-48 {
@@ -994,8 +1032,24 @@ select {
   height: 1.25rem;
 }
 
+.h-6 {
+  height: 1.5rem;
+}
+
+.h-60 {
+  height: 15rem;
+}
+
 .h-8 {
   height: 2rem;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.max-h-\[90vh\] {
+  max-height: 90vh;
 }
 
 .min-h-\[6rem\] {
@@ -1008,6 +1062,10 @@ select {
 
 .w-1\/4 {
   width: 25%;
+}
+
+.w-12 {
+  width: 3rem;
 }
 
 .w-14 {
@@ -1024,6 +1082,14 @@ select {
 
 .w-5 {
   width: 1.25rem;
+}
+
+.w-6 {
+  width: 1.5rem;
+}
+
+.w-8 {
+  width: 2rem;
 }
 
 .w-80 {
@@ -1066,8 +1132,17 @@ select {
   flex: none;
 }
 
+.flex-grow {
+  flex-grow: 1;
+}
+
 .translate-y-0 {
   --tw-translate-y: 0px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-y-2 {
+  --tw-translate-y: 0.5rem;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
@@ -1193,12 +1268,22 @@ select {
   border-color: rgb(244 244 245 / var(--tw-divide-opacity));
 }
 
+.overflow-auto {
+  overflow: auto;
+}
+
 .overflow-hidden {
   overflow: hidden;
 }
 
 .overflow-y-auto {
   overflow-y: auto;
+}
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .whitespace-nowrap {
@@ -1225,12 +1310,46 @@ select {
   border-radius: 0.375rem;
 }
 
+.rounded-l-md {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+
+.rounded-r-md {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+.rounded-tl {
+  border-top-left-radius: 0.25rem;
+}
+
 .border {
   border-width: 1px;
 }
 
+.border-2 {
+  border-width: 2px;
+}
+
+.border-b {
+  border-bottom-width: 1px;
+}
+
+.border-b-2 {
+  border-bottom-width: 2px;
+}
+
 .border-t {
   border-top-width: 1px;
+}
+
+.border-t-2 {
+  border-top-width: 2px;
+}
+
+.border-dashed {
+  border-style: dashed;
 }
 
 .border-blue-300 {
@@ -1253,6 +1372,16 @@ select {
   border-color: rgb(74 222 128 / var(--tw-border-opacity));
 }
 
+.border-indigo-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(99 102 241 / var(--tw-border-opacity));
+}
+
+.border-red-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 202 202 / var(--tw-border-opacity));
+}
+
 .border-rose-400 {
   --tw-border-opacity: 1;
   border-color: rgb(251 113 133 / var(--tw-border-opacity));
@@ -1270,6 +1399,11 @@ select {
 .border-zinc-300 {
   --tw-border-opacity: 1;
   border-color: rgb(212 212 216 / var(--tw-border-opacity));
+}
+
+.bg-black {
+  --tw-bg-opacity: 1;
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity));
 }
 
 .bg-blue-50 {
@@ -1295,6 +1429,11 @@ select {
 .bg-gray-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+}
+
+.bg-gray-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
 }
 
 .bg-gray-300 {
@@ -1327,6 +1466,11 @@ select {
   background-color: rgb(79 70 229 / var(--tw-bg-opacity));
 }
 
+.bg-red-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 242 242 / var(--tw-bg-opacity));
+}
+
 .bg-red-600 {
   --tw-bg-opacity: 1;
   background-color: rgb(220 38 38 / var(--tw-bg-opacity));
@@ -1354,6 +1498,28 @@ select {
 .bg-zinc-900 {
   --tw-bg-opacity: 1;
   background-color: rgb(24 24 27 / var(--tw-bg-opacity));
+}
+
+.bg-opacity-0 {
+  --tw-bg-opacity: 0;
+}
+
+.bg-opacity-50 {
+  --tw-bg-opacity: 0.5;
+}
+
+.bg-gradient-to-t {
+  background-image: linear-gradient(to top, var(--tw-gradient-stops));
+}
+
+.from-black {
+  --tw-gradient-from: #000 var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(0 0 0 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.to-transparent {
+  --tw-gradient-to: transparent var(--tw-gradient-to-position);
 }
 
 .fill-cyan-900 {
@@ -1623,6 +1789,11 @@ select {
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 
+.text-gray-800 {
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity));
+}
+
 .text-gray-900 {
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
@@ -1636,6 +1807,11 @@ select {
 .text-indigo-600 {
   --tw-text-opacity: 1;
   color: rgb(79 70 229 / var(--tw-text-opacity));
+}
+
+.text-red-700 {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity));
 }
 
 .text-rose-600 {
@@ -1676,6 +1852,10 @@ select {
 .text-zinc-900 {
   --tw-text-opacity: 1;
   color: rgb(24 24 27 / var(--tw-text-opacity));
+}
+
+.underline {
+  text-decoration-line: underline;
 }
 
 .antialiased {
@@ -1720,6 +1900,12 @@ select {
 .shadow-sm {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -1770,8 +1956,20 @@ select {
   transition-duration: 150ms;
 }
 
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .transition-opacity {
   transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-transform {
+  transition-property: transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1798,8 +1996,23 @@ select {
 
 /* Custom CSS can go here */
 
+.hover\:translate-y-0:hover {
+  --tw-translate-y: 0px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
 .hover\:cursor-pointer:hover {
   cursor: pointer;
+}
+
+.hover\:border-gray-300:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+}
+
+.hover\:border-gray-400:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity));
 }
 
 .hover\:bg-blue-600:hover {
@@ -1815,6 +2028,11 @@ select {
 .hover\:bg-gray-200:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(229 231 235 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-gray-300:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
 }
 
 .hover\:bg-gray-50:hover {
@@ -1857,9 +2075,23 @@ select {
   background-color: rgb(63 63 70 / var(--tw-bg-opacity));
 }
 
+.hover\:bg-opacity-30:hover {
+  --tw-bg-opacity: 0.3;
+}
+
+.hover\:text-gray-200:hover {
+  --tw-text-opacity: 1;
+  color: rgb(229 231 235 / var(--tw-text-opacity));
+}
+
 .hover\:text-gray-300:hover {
   --tw-text-opacity: 1;
   color: rgb(209 213 219 / var(--tw-text-opacity));
+}
+
+.hover\:text-gray-700:hover {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 
 .hover\:text-indigo-500:hover {
@@ -1876,6 +2108,10 @@ select {
   text-decoration-line: underline;
 }
 
+.hover\:opacity-100:hover {
+  opacity: 1;
+}
+
 .hover\:opacity-40:hover {
   opacity: 0.4;
 }
@@ -1883,6 +2119,11 @@ select {
 .focus\:border-blue-500:focus {
   --tw-border-opacity: 1;
   border-color: rgb(59 130 246 / var(--tw-border-opacity));
+}
+
+.focus\:border-indigo-500:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(99 102 241 / var(--tw-border-opacity));
 }
 
 .focus\:border-rose-400:focus {
@@ -1946,9 +2187,23 @@ select {
   color: rgb(255 255 255 / 0.8);
 }
 
+.group:hover .group-hover\:scale-110 {
+  --tw-scale-x: 1.1;
+  --tw-scale-y: 1.1;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
 .group:hover .group-hover\:bg-zinc-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(250 250 250 / var(--tw-bg-opacity));
+}
+
+.group:hover .group-hover\:bg-opacity-40 {
+  --tw-bg-opacity: 0.4;
+}
+
+.group:hover .group-hover\:opacity-100 {
+  opacity: 1;
 }
 
 .group:hover .group-hover\:opacity-70 {
@@ -1997,6 +2252,14 @@ select {
     margin-right: auto;
   }
 
+  .sm\:inline {
+    display: inline;
+  }
+
+  .sm\:h-72 {
+    height: 18rem;
+  }
+
   .sm\:w-96 {
     width: 24rem;
   }
@@ -2024,6 +2287,10 @@ select {
     --tw-scale-x: .95;
     --tw-scale-y: .95;
     transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+
+  .sm\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .sm\:gap-8 {
@@ -2075,6 +2342,10 @@ select {
 
   .md\:grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .md\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
### TL;DR

Added Unsplash image integration for event cover images with proper attribution.

### What changed?

- Added `unsplash_data` field to the Event schema to store image metadata
- Created a new ImagePickerComponent for selecting Unsplash images
- Implemented UnsplashService to handle API interactions
- Enhanced event forms with an image picker modal
- Updated event display to show cover images with proper attribution
- Added migration for the new database field

### How to test?

1. Set the `UNSPLASH_ACCESS_KEY` environment variable with a valid API key
2. Create or edit an event
3. Click on "Add a cover image" or "Change Image" 
4. Search for images on Unsplash
5. Select an image and verify it appears on the event form
6. Save the event and verify the image and attribution appear on the event page

### Why make this change?

This change improves the visual appeal of events by allowing organizers to easily add professional cover images. The integration with Unsplash provides access to a large library of high-quality images while ensuring proper attribution to photographers as required by Unsplash's terms of service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an integrated image picker for selecting Unsplash images as event cover images during event creation and editing.
  - Displayed photographer credit and Unsplash attribution for selected cover images.
  - Enhanced event forms to support cover image selection, preview, and metadata storage.

- **User Interface**
  - Introduced a modal dialog for browsing and selecting Unsplash images.
  - Improved event detail pages with responsive cover image display and photo credit overlays.
  - Expanded CSS utility classes for richer layouts, styling, and responsive design.

- **Bug Fixes**
  - None.

- **Documentation**
  - None.

- **Chores**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->