### PR TITLE
small bug

### DIFF
--- a/lib/eventasaurus_web/live/event_live/edit.ex
+++ b/lib/eventasaurus_web/live/event_live/edit.ex
@@ -214,24 +214,19 @@ defmodule EventasaurusWeb.EventLive.Edit do
 
   @impl true
   def handle_event("venue_selected", venue_data, socket) do
-    # Extract data from venue_data with proper defaults
-    name = Map.get(venue_data, "name", "") || ""
-    address = Map.get(venue_data, "address", "") || ""
-    city = Map.get(venue_data, "city", "") || ""
-    state = Map.get(venue_data, "state", "") || ""
-    country = Map.get(venue_data, "country", "") || ""
-    latitude = Map.get(venue_data, "latitude") || nil
-    longitude = Map.get(venue_data, "longitude") || nil
-
-    # Update the form_data with the selected venue
-    form_data = socket.assigns.form_data
-    |> Map.put("venue_name", name)
-    |> Map.put("venue_address", address)
-    |> Map.put("venue_city", city)
-    |> Map.put("venue_state", state)
-    |> Map.put("venue_country", country)
-    |> Map.put("venue_latitude", latitude)
-    |> Map.put("venue_longitude", longitude)
+    # Extract venue data with defaults
+    venue_name = Map.get(venue_data, "name", "")
+    venue_address = Map.get(venue_data, "address", "")
+    
+    # Update form data with venue information while preserving existing data
+    form_data = (socket.assigns.form_data || %{})
+    |> Map.put("venue_name", venue_name)
+    |> Map.put("venue_address", venue_address)
+    |> Map.put("venue_city", Map.get(venue_data, "city", ""))
+    |> Map.put("venue_state", Map.get(venue_data, "state", ""))
+    |> Map.put("venue_country", Map.get(venue_data, "country", ""))
+    |> Map.put("venue_latitude", Map.get(venue_data, "latitude"))
+    |> Map.put("venue_longitude", Map.get(venue_data, "longitude"))
     |> Map.put("is_virtual", false)
 
     # Update the socket with full information and the changeset
@@ -243,8 +238,8 @@ defmodule EventasaurusWeb.EventLive.Edit do
     socket = socket
     |> assign(:form_data, form_data)
     |> assign(:changeset, changeset)
-    |> assign(:selected_venue_name, name)
-    |> assign(:selected_venue_address, address)
+    |> assign(:selected_venue_name, venue_name)
+    |> assign(:selected_venue_address, venue_address)
     |> assign(:is_virtual, false)
 
     {:noreply, socket}

--- a/lib/eventasaurus_web/live/event_live/new.ex
+++ b/lib/eventasaurus_web/live/event_live/new.ex
@@ -188,20 +188,20 @@ defmodule EventasaurusWeb.EventLive.New do
     IO.puts("\n======================== VENUE SELECTED ========================")
     IO.inspect(venue_data, label: "DEBUG - Received venue data")
 
-    # Extract data from venue_data with proper defaults
-    name = Map.get(venue_data, "name", "")
-    address = Map.get(venue_data, "address", "")
-
-    # Update the form data with venue information
-    form_data = %{
-      "venue_name" => name,
-      "venue_address" => address,
-      "venue_city" => Map.get(venue_data, "city", ""),
-      "venue_state" => Map.get(venue_data, "state", ""),
-      "venue_country" => Map.get(venue_data, "country", ""),
-      "venue_latitude" => Map.get(venue_data, "latitude"),
-      "venue_longitude" => Map.get(venue_data, "longitude")
-    }
+    # Extract venue data with defaults
+    venue_name = Map.get(venue_data, "name", "")
+    venue_address = Map.get(venue_data, "address", "")
+    
+    # Update form data with venue information while preserving existing data
+    form_data = (socket.assigns.form_data || %{})
+    |> Map.put("venue_name", venue_name)
+    |> Map.put("venue_address", venue_address)
+    |> Map.put("venue_city", Map.get(venue_data, "city", ""))
+    |> Map.put("venue_state", Map.get(venue_data, "state", ""))
+    |> Map.put("venue_country", Map.get(venue_data, "country", ""))
+    |> Map.put("venue_latitude", Map.get(venue_data, "latitude"))
+    |> Map.put("venue_longitude", Map.get(venue_data, "longitude"))
+    |> Map.put("is_virtual", false)
 
     # Update the changeset
     changeset =
@@ -214,8 +214,8 @@ defmodule EventasaurusWeb.EventLive.New do
       socket
       |> assign(:form_data, form_data)
       |> assign(:changeset, changeset)
-      |> assign(:selected_venue_name, name)
-      |> assign(:selected_venue_address, address)
+      |> assign(:selected_venue_name, venue_name)
+      |> assign(:selected_venue_address, venue_address)
       |> assign(:is_virtual, false)
 
     {:noreply, socket}


### PR DESCRIPTION
### TL;DR

Refactored venue selection handling to preserve existing form data when selecting a venue.

### What changed?

- Improved the `venue_selected` event handler in both `edit.ex` and `new.ex` files
- Changed the approach to update form data by preserving existing values instead of creating a new map
- Renamed variables for better clarity (`name` → `venue_name`, `address` → `venue_address`)
- Added explicit handling for the `is_virtual` field in the `new.ex` file
- Made the code more consistent between the edit and new components

### How to test?

1. Create a new event and select a venue from the venue picker
2. Verify that any previously entered form data is preserved after venue selection
3. Edit an existing event and change the venue
4. Confirm that all form fields maintain their values after venue selection
5. Check that the `is_virtual` flag is properly set to false when selecting a physical venue

### Why make this change?

The previous implementation was creating a new form data map in the `new.ex` file, which would discard any data the user had already entered. This change ensures a consistent approach between both components and preserves user input when selecting a venue, providing a better user experience by not requiring re-entry of information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of venue selection in event editing and creation by making form updates more concise and ensuring safer defaults.
  - Clarified variable naming for venue information and updated how venue data is merged into existing form data.
  - Enhanced reliability when updating selected venue details and form state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->