### PR TITLE
tiny

### DIFF
--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -149,7 +149,7 @@ defmodule EventasaurusWeb.PublicEventLive do
             <div class="bg-white border border-gray-200 rounded-xl p-6 mb-8 shadow-sm">
               <h2 class="text-xl font-semibold mb-4 text-gray-900">About This Event</h2>
               <div class="prose max-w-none text-gray-700">
-                <%= Phoenix.HTML.raw(Earmark.as_html!(@event.description || "")) %>
+                <%= Phoenix.HTML.raw(Earmark.as_html!(@event.description)) %>
               </div>
             </div>
           <% else %>


### PR DESCRIPTION
### TL;DR

Remove fallback empty string for event description rendering

### What changed?

Removed the `|| ""` fallback in the event description rendering. Previously, when an event description was `nil`, it would default to an empty string before being passed to `Earmark.as_html!()`.

### How to test?

1. Create or edit an event with a nil description
2. View the public event page
3. Verify that the description renders correctly without errors

### Why make this change?

This change simplifies the code by removing an unnecessary fallback. The `Earmark.as_html!()` function can handle `nil` values appropriately, making the explicit fallback to an empty string redundant.