### PR TITLE
fixed gradiant

### DIFF
--- a/lib/eventasaurus_web/components/layouts/app.html.heex
+++ b/lib/eventasaurus_web/components/layouts/app.html.heex
@@ -3,9 +3,15 @@
   
   <div class="min-h-screen py-8">
     <.container>
-      <div class="bg-white/60 backdrop-blur-sm rounded-2xl border border-white/20 p-8">
-        <%= @inner_content %>
-      </div>
+      <%= unless assigns[:hide_gradient] do %>
+        <div class="p-8">
+          <%= @inner_content %>
+        </div>
+      <% else %>
+        <div class="bg-white/60 backdrop-blur-sm rounded-2xl border border-white/20 p-8">
+          <%= @inner_content %>
+        </div>
+      <% end %>
     </.container>
   </div>
 </main> 

--- a/lib/eventasaurus_web/components/layouts/root.html.heex
+++ b/lib/eventasaurus_web/components/layouts/root.html.heex
@@ -72,6 +72,13 @@
     data-supabase-url={supabase_url}
     data-supabase-api-key={supabase_api_key}
   >
+    <!-- Gradient Background for pages that need it -->
+    <%= unless assigns[:hide_gradient] do %>
+      <div class="fixed inset-0 -z-10 overflow-hidden">
+        <.gradient_background theme="default" />
+      </div>
+    <% end %>
+    
     <!-- Radiant-style Header -->
     <header class="border-b border-white/10 backdrop-blur-md sticky top-0 z-40">
       <.container class="py-4">


### PR DESCRIPTION
### TL;DR

Added a conditional gradient background that can be toggled with the `hide_gradient` assign.

### What changed?

- Modified the layout structure to conditionally render content with or without the gradient background
- Added a gradient background div in the root layout that only renders when `hide_gradient` is not set
- Reversed the conditional logic in app.html.heex to apply the white backdrop styling only when gradients are hidden

### How to test?

1. Set `hide_gradient` assign to `true` in a controller or live view:
   ```elixir
   assign(socket, :hide_gradient, true)
   ```
2. Verify that pages with `hide_gradient: true` show content with the white backdrop and no gradient
3. Verify that pages without this assign show the gradient background without the white backdrop

### Why make this change?

This change provides flexibility in page styling by allowing certain pages to opt out of the gradient background. This is useful for pages that need a cleaner, simpler background or where the gradient might interfere with content visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a gradient background that appears behind the main content, unless disabled by specific settings.

- **Style**
  - Updated container styling to conditionally switch between a simple padded layout and a more decorative style with background, blur, border, and rounded corners, based on user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->