### PR TITLE
phase 3

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -34,8 +34,8 @@
   --input-border-radius: 6px;
 }
 
-/* Theme container styles */
-.theme-container {
+/* Theme body styles - applies to any themed body */
+body[class*="theme-"] {
   position: relative;
   background-color: var(--color-background);
   color: var(--color-text);
@@ -50,7 +50,7 @@
 }
 
 /* Theme buttons */
-.theme-container .theme-button-primary {
+body[class*="theme-"] .theme-button-primary {
   background-color: var(--color-primary);
   color: white;
   border: none;
@@ -65,12 +65,12 @@
   z-index: 10;
 }
 
-.theme-container .theme-button-primary:hover {
+body[class*="theme-"] .theme-button-primary:hover {
   transform: translateY(-1px);
   box-shadow: var(--shadow-style-large);
 }
 
-.theme-container .theme-button-secondary {
+body[class*="theme-"] .theme-button-secondary {
   background-color: transparent;
   color: var(--color-primary);
   border: 2px solid var(--color-border);
@@ -84,12 +84,12 @@
   z-index: 10;
 }
 
-.theme-container .theme-button-secondary:hover {
+body[class*="theme-"] .theme-button-secondary:hover {
   background-color: var(--color-border);
 }
 
 /* Theme cards */
-.theme-container .theme-card {
+body[class*="theme-"] .theme-card {
   background-color: var(--color-background);
   border: 1px solid var(--color-border);
   border-radius: var(--card-border-radius);
@@ -99,7 +99,7 @@
   z-index: 5;
 }
 
-.theme-container .theme-card:hover {
+body[class*="theme-"] .theme-card:hover {
   box-shadow: var(--shadow-style-large);
 }
 

--- a/assets/css/themes/celebration.css
+++ b/assets/css/themes/celebration.css
@@ -9,9 +9,9 @@
   --color-border: #f9a8d4; /* Pink 300 */
   
   /* Typography */
-  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-family-heading: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --heading-weight: 700;
+  --font-family: 'Fredoka', 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-family-heading: 'Fredoka', 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --heading-weight: 600;
   --body-size: 16px;
   --body-weight: 400;
   

--- a/assets/css/themes/nature.css
+++ b/assets/css/themes/nature.css
@@ -9,8 +9,8 @@
   --color-border: #bbf7d0; /* Green 200 */
   
   /* Typography */
-  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-family-heading: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-family: 'Merriweather', 'Georgia', 'Times New Roman', serif;
+  --font-family-heading: 'Merriweather', 'Georgia', 'Times New Roman', serif;
   --heading-weight: 600;
   --body-size: 16px;
   --body-weight: 400;

--- a/assets/css/themes/professional.css
+++ b/assets/css/themes/professional.css
@@ -9,8 +9,8 @@
   --color-border: #e2e8f0; /* Slate 200 */
   
   /* Typography */
-  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-family-heading: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-family: 'Montserrat', 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-family-heading: 'Montserrat', 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   --heading-weight: 600;
   --body-size: 16px;
   --body-weight: 400;

--- a/assets/css/themes/retro.css
+++ b/assets/css/themes/retro.css
@@ -9,8 +9,8 @@
   --color-border: #fbbf24; /* Amber 400 */
   
   /* Typography */
-  --font-family: 'Georgia', 'Times New Roman', serif;
-  --font-family-heading: 'Georgia', 'Times New Roman', serif;
+  --font-family: 'Playfair Display', 'Georgia', 'Times New Roman', serif;
+  --font-family-heading: 'Playfair Display', 'Georgia', 'Times New Roman', serif;
   --heading-weight: 700;
   --body-size: 17px;
   --body-weight: 400;
@@ -95,7 +95,7 @@
 }
 
 .theme-retro .event-title {
-  font-family: 'Georgia', 'Times New Roman', serif;
+  font-family: 'Playfair Display', 'Georgia', 'Times New Roman', serif;
   font-weight: 700;
   text-shadow: 2px 2px 0px rgba(217, 119, 6, 0.3);
   color: #451a03;
@@ -106,7 +106,7 @@
   background: #fed7aa; /* Orange 200 */
   border: 3px solid #ea580c; /* Orange 600 */
   box-shadow: 4px 4px 0px #c2410c; /* Orange 700 */
-  font-family: 'Georgia', 'Times New Roman', serif;
+  font-family: 'Playfair Display', 'Georgia', 'Times New Roman', serif;
   font-weight: 700;
 }
 
@@ -114,7 +114,7 @@
   background: #fde68a;
   border: 3px solid #f59e0b;
   box-shadow: inset 2px 2px 4px rgba(217, 119, 6, 0.2);
-  font-family: 'Georgia', 'Times New Roman', serif;
+  font-family: 'Playfair Display', 'Georgia', 'Times New Roman', serif;
 }
 
 .theme-retro .form-input:focus {

--- a/assets/css/themes/velocity.css
+++ b/assets/css/themes/velocity.css
@@ -9,8 +9,8 @@
   --color-border: #e5e5e5; /* Neutral 200 */
   
   /* Typography */
-  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-family-heading: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-family: 'Rajdhani', 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-family-heading: 'Rajdhani', 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   --heading-weight: 800;
   --body-size: 16px;
   --body-weight: 400;

--- a/lib/eventasaurus_web/components/layouts/root.html.heex
+++ b/lib/eventasaurus_web/components/layouts/root.html.heex
@@ -18,7 +18,9 @@
     <% end %>
     
     <!-- Theme font links -->
-    <%= EventasaurusWeb.ThemeHelpers.theme_font_links() %>
+    <%= if assigns[:theme] do %>
+      <%= Phoenix.HTML.raw(EventasaurusWeb.ThemeHelpers.theme_font_link(assigns[:theme])) %>
+    <% end %>
     
     <!-- Google Fonts - Knewave for logo -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -88,27 +90,27 @@
     <% end %>
     
     <!-- Radiant-style Header -->
-    <header class="border-b border-white/10 dark:border-white/10 backdrop-blur-md sticky top-0 z-40 bg-white/80 dark:bg-gray-900/20">
+    <header class="border-b border-white/10 backdrop-blur-md sticky top-0 z-40">
       <.container class="py-4">
         <nav class="flex items-center justify-between">
           <div class="flex items-center space-x-8">
-            <.logo theme={assigns[:theme]} />
+            <.logo />
             <%= if @conn.assigns[:user] do %>
               <div class="hidden lg:flex items-center space-x-6">
-                <a href="/dashboard" class="text-sm font-medium text-gray-700 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white">
+                <a href="/dashboard" class="text-sm font-medium text-gray-700 hover:text-gray-950">
                   Dashboard
                 </a>
-                <a href="/events" class="text-sm font-medium text-gray-700 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white">
+                <a href="/events" class="text-sm font-medium text-gray-700 hover:text-gray-950">
                   My Events
                 </a>
-                <a href="/about" class="text-sm font-medium text-gray-700 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white">
+                <a href="/about" class="text-sm font-medium text-gray-700 hover:text-gray-950">
                   About
                 </a>
               </div>
             <% else %>
               <div class="hidden sm:flex items-center space-x-6">
-                <a href="/about" class="text-sm font-medium text-gray-700 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white">About</a>
-                <a href="/whats-new" class="text-sm font-medium text-gray-700 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white">What's New</a>
+                <a href="/about" class="text-sm font-medium text-gray-700 hover:text-gray-950">About</a>
+                <a href="/whats-new" class="text-sm font-medium text-gray-700 hover:text-gray-950">What's New</a>
               </div>
             <% end %>
           </div>
@@ -116,18 +118,18 @@
           <div class="flex items-center space-x-4">
             <%= if @conn.assigns[:user] do %>
               <!-- Authenticated user UI -->
-              <span class="text-sm text-gray-700 dark:text-gray-300">
+              <span class="text-sm text-gray-700">
                 <%= @conn.assigns[:user].email %>
               </span>
-              <a href="/auth/logout" class="text-sm font-medium text-gray-700 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white">
+              <a href="/auth/logout" class="text-sm font-medium text-gray-700 hover:text-gray-950">
                 Log out
               </a>
             <% else %>
               <!-- Anonymous user UI -->
-              <a href="/login" class="text-sm font-medium text-gray-700 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white">
+              <a href="/login" class="text-sm font-medium text-gray-700 hover:text-gray-950">
                 Sign In
               </a>
-              <a href="/register" class="inline-flex items-center justify-center px-4 py-2 rounded-full border border-transparent shadow-md text-base font-medium whitespace-nowrap bg-gray-950 text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100">
+              <a href="/register" class="inline-flex items-center justify-center px-4 py-2 rounded-full border border-transparent bg-gray-950 shadow-md text-base font-medium whitespace-nowrap text-white hover:bg-gray-800">
                 Get Started
               </a>
             <% end %>


### PR DESCRIPTION
### TL;DR

Refactored theme styling to use body element selectors instead of container classes and updated font families across all themes.

### What changed?

- Changed CSS selectors from `.theme-container` to `body[class*="theme-"]` for better theme application
- Updated font families in all theme files:
  - Celebration: Changed to 'Fredoka' and reduced heading weight from 700 to 600
  - Nature: Changed to 'Merriweather' serif font
  - Professional: Changed to 'Montserrat' font
  - Retro: Changed to 'Playfair Display' font
  - Velocity: Changed to 'Rajdhani' font
- Modified the theme font loading in the root layout to only load fonts when a theme is assigned

### How to test?

1. View each themed page (Celebration, Nature, Professional, Retro, Velocity)
2. Verify the new fonts are loading correctly
3. Confirm that all themed elements (buttons, cards, etc.) maintain proper styling
4. Test responsive behavior across different screen sizes

### Why make this change?

This change improves theme implementation by applying styles directly to the body element rather than requiring a container div. It also enhances visual differentiation between themes by using more distinctive, theme-appropriate fonts that better match each theme's personality and purpose.