### PR TITLE
nearly there

### DIFF
--- a/lib/eventasaurus_web/components/layouts/root.html.heex
+++ b/lib/eventasaurus_web/components/layouts/root.html.heex
@@ -106,7 +106,7 @@
     end
 %>
   <body class={[
-      "bg-white antialiased overflow-x-hidden",
+      "bg-white antialiased overflow-x-hidden min-h-screen flex flex-col",
       # Apply theme class to body for universal background application
       assigns[:theme] && EventasaurusWeb.ThemeHelpers.theme_class(assigns[:theme])
     ]}
@@ -122,7 +122,7 @@
     <% end %>
     
     <!-- Navbar - Protected UI Element (always uses Inter font) -->
-    <header class="navbar border-b border-white/10 backdrop-blur-md sticky top-0 z-40">
+    <header class="navbar border-b border-white/10 backdrop-blur-md sticky top-0 z-40 flex-shrink-0">
       <.container class="py-4">
         <nav class="flex items-center justify-between">
           <div class="flex items-center space-x-8">
@@ -170,13 +170,13 @@
       </.container>
     </header>
 
-    <!-- Main content wrapper - Theme fonts apply here -->
-    <main class="main-content">
+    <!-- Main content wrapper - Theme fonts apply here, grows to fill available space -->
+    <main class="main-content flex-grow">
       <%= @inner_content %>
     </main>
 
     <!-- Footer - Protected UI Element (always uses Inter font) -->
-    <footer class="footer bg-gray-950 text-white mt-0">
+    <footer class="footer bg-gray-950 text-white mt-0 flex-shrink-0">
       <.container class="py-6">
         <div class="grid grid-cols-1 lg:grid-cols-4 gap-8">
           <div class="lg:col-span-2">

--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -282,7 +282,7 @@ defmodule EventasaurusWeb.PublicEventLive do
   def render(assigns) do
     ~H"""
     <!-- Public Event Show Page with dynamic theming -->
-    <div class="container mx-auto px-6 py-4">
+    <div class="container mx-auto px-6 py-12 max-w-7xl">
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
         <div class="lg:col-span-2">
           <!-- Date/time and main info -->
@@ -353,7 +353,7 @@ defmodule EventasaurusWeb.PublicEventLive do
           <% end %>
 
           <!-- Host section -->
-          <div class="border-t border-gray-200 pt-8 mt-8">
+          <div class="border-t border-gray-200 pt-6 mt-6">
             <h3 class="text-lg font-semibold mb-4 text-gray-900">Hosted by</h3>
             <div class="flex items-center space-x-3">
               <%= if @event.users != [] do %>


### PR DESCRIPTION
### TL;DR

Improved layout structure to ensure the footer stays at the bottom of the page and enhanced the public event page spacing.

### What changed?

- Added `min-h-screen flex flex-col` to the body element to create a proper sticky footer layout
- Added `flex-grow` to the main content wrapper to ensure it expands to fill available space
- Added `flex-shrink-0` to both header and footer to prevent them from shrinking
- Improved the public event page container with better padding (`py-12` instead of `py-4`) and a maximum width (`max-w-7xl`)
- Reduced spacing in the host section of the public event page (from `pt-8 mt-8` to `pt-6 mt-6`)

### How to test?

1. View any page with minimal content to verify the footer stays at the bottom of the viewport
2. Check the public event page to ensure proper spacing between elements
3. Verify the layout looks good on both desktop and mobile viewports
4. Test with different content lengths to ensure the footer behavior is consistent

### Why make this change?

This change fixes the "floating footer" issue that occurred on pages with minimal content, where the footer would appear in the middle of the page instead of at the bottom. It also improves the spacing and layout of the public event page for better readability and visual hierarchy.