### PR TITLE
protext delete

### DIFF
--- a/lib/eventasaurus_web/router.ex
+++ b/lib/eventasaurus_web/router.ex
@@ -68,12 +68,18 @@ defmodule EventasaurusWeb.Router do
     get "/dashboard", DashboardController, :index
   end
 
-  # Event routes (both public and protected)
+  # Protected event routes that require authentication
+  scope "/events", EventasaurusWeb do
+    pipe_through [:browser, :authenticated]
+
+    delete "/:slug", EventController, :delete
+  end
+
+  # Public event routes
   scope "/events", EventasaurusWeb do
     pipe_through :browser
 
     get "/:slug", EventController, :show
-    delete "/:slug", EventController, :delete
     get "/:slug/attendees", EventController, :attendees
   end
 


### PR DESCRIPTION
### TL;DR

Move the delete event route behind authentication to prevent unauthorized event deletion.

### What changed?

Restructured the router to separate event routes into two scopes:
- Created a new protected scope for routes requiring authentication, which now contains the `delete "/:slug"` route
- Kept the public event routes in a separate scope without authentication requirements

### How to test?

1. Try to delete an event while logged out - you should be redirected to the login page
2. Log in and verify you can delete an event successfully
3. Verify that viewing events and attendees still works without authentication

### Why make this change?

This change fixes a security vulnerability where any user could delete any event without authentication. By moving the delete route behind the authentication pipeline, we ensure that only authenticated users can delete events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Event deletion now requires authentication, enhancing security for this action.

- **Refactor**
  - Updated event routes to clearly separate public access (viewing events and attendees) from protected actions (deleting events).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->