### PR TITLE
fixing routes

### DIFF
--- a/lib/eventasaurus_web/controllers/event_controller.ex
+++ b/lib/eventasaurus_web/controllers/event_controller.ex
@@ -10,35 +10,41 @@ defmodule EventasaurusWeb.EventController do
       nil ->
         conn
         |> put_flash(:error, "Event not found")
-        |> redirect(to: ~p"/")
+        |> redirect(to: ~p"/dashboard")
 
       event ->
-        # Get the current user if authenticated
-        user = case ensure_user_struct(conn.assigns.auth_user) do
-          {:ok, user} -> user
-          {:error, _} -> nil
+        # Get the current user (required due to authentication pipeline)
+        case ensure_user_struct(conn.assigns.auth_user) do
+          {:ok, user} ->
+            # Check if user can manage this event
+            if Events.user_can_manage_event?(user, event) do
+              # Get registration status for the organizer
+              registration_status = Events.get_user_registration_status(event, user)
+
+              # Load venue and organizers for the event
+              venue = if event.venue_id, do: Venues.get_venue(event.venue_id), else: nil
+              organizers = Events.list_event_organizers(event)
+
+              # Load participants (guests) for the event
+              participants = Events.list_event_participants(event)
+                            |> Enum.sort_by(& &1.inserted_at, {:desc, NaiveDateTime})
+
+              conn
+              |> assign(:venue, venue)
+              |> assign(:organizers, organizers)
+              |> assign(:participants, participants)
+              |> render(:show, event: event, user: user, registration_status: registration_status)
+            else
+              conn
+              |> put_flash(:error, "You don't have permission to manage this event")
+              |> redirect(to: ~p"/dashboard")
+            end
+
+          {:error, _} ->
+            conn
+            |> put_flash(:error, "Authentication error")
+            |> redirect(to: ~p"/auth/login")
         end
-
-        # Get registration status if user is authenticated
-        registration_status = if user do
-          Events.get_user_registration_status(event, user)
-        else
-          :not_authenticated
-        end
-
-        # Load venue and organizers for the event
-        venue = if event.venue_id, do: Venues.get_venue(event.venue_id), else: nil
-        organizers = Events.list_event_organizers(event)
-
-        # Load participants (guests) for the event
-        participants = Events.list_event_participants(event)
-                      |> Enum.sort_by(& &1.inserted_at, {:desc, NaiveDateTime})
-
-        conn
-        |> assign(:venue, venue)
-        |> assign(:organizers, organizers)
-        |> assign(:participants, participants)
-        |> render(:show, event: event, user: user, registration_status: registration_status)
     end
   end
 

--- a/lib/eventasaurus_web/router.ex
+++ b/lib/eventasaurus_web/router.ex
@@ -72,15 +72,9 @@ defmodule EventasaurusWeb.Router do
   scope "/events", EventasaurusWeb do
     pipe_through [:browser, :authenticated]
 
-    delete "/:slug", EventController, :delete
-  end
-
-  # Public event routes
-  scope "/events", EventasaurusWeb do
-    pipe_through :browser
-
     get "/:slug", EventController, :show
     get "/:slug/attendees", EventController, :attendees
+    delete "/:slug", EventController, :delete
   end
 
   # Public routes with auth user assignment

--- a/test/eventasaurus_web/features/auth_notification_test.exs
+++ b/test/eventasaurus_web/features/auth_notification_test.exs
@@ -3,6 +3,7 @@ defmodule EventasaurusWeb.Features.AuthNotificationTest do
 
   import Wallaby.Query, only: [css: 1]
   import Wallaby.Browser
+  import EventasaurusApp.Factory
 
   describe "authentication notification behavior" do
     test "should show only one 'You must log in' message when accessing protected page", %{session: session} do
@@ -29,6 +30,81 @@ defmodule EventasaurusWeb.Features.AuthNotificationTest do
 
       # Verify that the error flash has the proper "Error!" title
       assert String.contains?(page_text, "Error!"), "Expected flash message to contain 'Error!' title"
+    end
+  end
+
+  describe "event management authorization vulnerabilities" do
+    setup do
+      # Create a user and their event using proper Events context
+      user = insert(:user)
+
+      # Create an event with organizer using the Events context function
+      event_attrs = %{
+        title: "My Private Event",
+        description: "This is my private event that only I should be able to manage",
+        start_at: DateTime.utc_now() |> DateTime.add(7, :day),
+        timezone: "America/Los_Angeles",
+        visibility: :public
+      }
+
+      {:ok, event} = EventasaurusApp.Events.create_event_with_organizer(event_attrs, user)
+
+      %{user: user, event: event}
+    end
+
+    test "✅ SECURITY FIXED: unauthenticated user cannot access event management page", %{session: session, event: event} do
+      # Visit the event management page without being logged in
+      session = session |> visit("/events/#{event.slug}")
+
+      # Should be redirected to login (SECURITY FIXED)
+      current_url = session |> current_url()
+
+      # This assertion should now PASS, showing the security fix worked
+      assert String.contains?(current_url, "/auth/login"),
+        "✅ SECURITY FIXED: Unauthenticated user properly redirected to login. URL: #{current_url}"
+    end
+
+    test "✅ SECURITY FIXED: event management page properly protected", %{session: session, event: event} do
+      # Visit the event management page without being logged in
+      session = session |> visit("/events/#{event.slug}")
+
+      current_url = session |> current_url()
+      page_text = Wallaby.Browser.text(session)
+
+      # Verify we're on the login page
+      assert String.contains?(current_url, "/auth/login"),
+        "Should be redirected to login page"
+
+      # Verify we see the login form, not the event management page
+      assert String.contains?(page_text, "Sign in to account"),
+        "Should see login form"
+
+      # Verify we don't see any event management content
+      refute String.contains?(page_text, event.title),
+        "Should not see event title on login page"
+    end
+
+    test "✅ AUTHORIZATION: users can only access events they organize", %{event: event} do
+      # Create a different user (not the event organizer)
+      other_user = insert(:user)
+
+      # Create another event owned by the other user
+      other_event_attrs = %{
+        title: "Other User's Event",
+        description: "This event belongs to someone else",
+        start_at: DateTime.utc_now() |> DateTime.add(14, :day),
+        timezone: "America/Los_Angeles",
+        visibility: :public
+      }
+
+      {:ok, other_event} = EventasaurusApp.Events.create_event_with_organizer(other_event_attrs, other_user)
+
+      # Verify ownership relationships
+      assert EventasaurusApp.Events.user_can_manage_event?(other_user, other_event),
+        "Other user should be able to manage their own event"
+
+      refute EventasaurusApp.Events.user_can_manage_event?(other_user, event),
+        "Other user should NOT be able to manage the first user's event"
     end
   end
 end

--- a/test/eventasaurus_web/integration/route_integration_test.exs
+++ b/test/eventasaurus_web/integration/route_integration_test.exs
@@ -107,8 +107,8 @@ defmodule EventasaurusWeb.RouteIntegrationTest do
       user = EventasaurusApp.AccountsFixtures.user_fixture()
       event = EventasaurusApp.EventsFixtures.event_fixture(%{user_id: user.id})
 
-      # Test that the public event page loads using slug
-      conn = get(conn, ~p"/events/#{event.slug}")
+      # Test that the public event page loads using slug (this should be the LiveView route /:slug)
+      conn = get(conn, ~p"/#{event.slug}")
       assert html_response(conn, 200) =~ event.title
     end
 


### PR DESCRIPTION
### TL;DR

Enhanced security for event management pages by enforcing proper authentication and authorization checks.

### What changed?

- Added proper authentication enforcement for event management pages
- Implemented authorization checks to ensure users can only manage events they organize
- Updated redirects to send users to the dashboard instead of the homepage
- Fixed security vulnerabilities in the event controller by requiring authentication
- Modified router to ensure all event management routes require authentication
- Updated tests to verify security fixes are working correctly

### How to test?

1. Try accessing `/events/{slug}` without being logged in - should redirect to login
2. Log in as a user who is not an organizer of an event and try to access `/events/{slug}` - should redirect to dashboard with error message
3. Log in as an event organizer and verify you can access the management page for your own events
4. Verify public event pages at `/{slug}` still work without authentication

### Why make this change?

This change addresses critical security vulnerabilities where event management pages were accessible to unauthenticated users or users who weren't event organizers. The fix ensures proper authentication and authorization checks are in place, preventing unauthorized access to event management functionality while maintaining public access to event landing pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access control for event management pages, requiring authentication and organizer permissions.
  - Unauthenticated users are now redirected to the login page when accessing protected admin pages.
  - Users without organizer rights are redirected to the dashboard with an appropriate error message.
  - Missing events now redirect to the dashboard instead of the homepage.

- **Tests**
  - Enhanced test coverage to verify authentication and authorization enforcement on admin and management pages.
  - Added and updated tests to ensure public event pages remain accessible without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->