### PR TITLE
before tests

### DIFF
--- a/lib/eventasaurus_web/live/event_live/new.ex
+++ b/lib/eventasaurus_web/live/event_live/new.ex
@@ -11,7 +11,7 @@ defmodule EventasaurusWeb.EventLive.New do
   alias EventasaurusWeb.Services.SearchService
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(_params, session, socket) do
     # auth_user is already assigned by the on_mount hook
     # Ensure we have a proper User struct for creating events
     case ensure_user_struct(socket.assigns.auth_user) do
@@ -46,6 +46,7 @@ defmodule EventasaurusWeb.EventLive.New do
           |> assign(:per_page, 20)
           |> assign_new(:image_tab, fn -> "unsplash" end)
           |> assign(:enable_date_polling, false)
+          |> assign(:supabase_access_token, session["access_token"])
 
         {:ok, socket}
 


### PR DESCRIPTION
### TL;DR

Added Supabase access token to socket assigns in the event creation page.

### What changed?

Modified the `mount/3` function in `EventLive.New` to:
1. Accept the `session` parameter (previously ignored with underscore)
2. Add the Supabase access token from the session to socket assigns with `assign(:supabase_access_token, session["access_token"])`

### How to test?

1. Log in to the application
2. Navigate to the event creation page
3. Verify that functionality requiring authentication (like image uploads or API calls) works correctly
4. Check browser console for any authentication-related errors

### Why make this change?

The Supabase access token is needed in the socket assigns to authenticate API requests made from the event creation page. Without this token, certain operations that require authentication (like accessing protected resources or uploading images) would fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The application now assigns your Supabase access token from the session when creating a new event, improving integration with Supabase services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->