### PR TITLE
Finishing touches

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,124 @@
+# Deployment Guide
+
+## Environment Variables
+
+### Required Variables
+- `SUPABASE_URL` - Your Supabase project URL
+- `SUPABASE_ANON_KEY` - Your Supabase anonymous key
+- `SUPABASE_DATABASE_URL` - Database connection string from Supabase
+- `SECRET_KEY_BASE` - Phoenix secret key base
+
+### Optional Variables
+- `POOL_SIZE` - Database connection pool size (default: 5)
+- `SITE_URL` - Your site URL (default: "https://eventasaur.us")
+- `SSL_VERIFY_PEER` - Enable SSL certificate verification (default: false)
+
+## SSL Configuration
+
+### SSL_VERIFY_PEER Environment Variable
+
+**Default Behavior**: SSL certificate verification is **disabled** (`verify_none`) for Supabase compatibility.
+
+**Purpose**: The `SSL_VERIFY_PEER` environment variable controls database SSL certificate verification.
+
+**Values**:
+- `SSL_VERIFY_PEER=true` - Enables SSL certificate verification (`verify_peer`)
+- `SSL_VERIFY_PEER=false` or unset - Disables SSL verification (`verify_none`) - **Default**
+
+### Why SSL Verification is Disabled by Default
+
+**Supabase Compatibility**: Supabase uses cloud-managed SSL certificates that may not work with standard certificate verification in containerized environments like Fly.io.
+
+**Production Considerations**:
+- Supabase provides secure, managed database connections
+- Cloud-managed certificates don't require custom CA bundles
+- Disabling verification is a common practice with managed database services
+- The connection is still encrypted (SSL/TLS is still active)
+
+### Security Guidelines
+
+#### ✅ **SAFE to use `SSL_VERIFY_PEER=false` when**:
+- Using Supabase (recommended)
+- Using other managed database services (RDS, Cloud SQL, etc.)
+- Deploying to containerized environments (Docker, Fly.io, etc.)
+
+#### ⚠️ **CONSIDER enabling `SSL_VERIFY_PEER=true` when**:
+- Using self-managed PostgreSQL with proper CA certificates
+- Corporate environments with custom certificate authorities
+- Specific compliance requirements mandate certificate verification
+
+#### 🚨 **MONITORING**:
+- The application logs a warning when SSL verification is disabled
+- Monitor deployment logs to ensure this is intentional
+- Review SSL settings during security audits
+
+### Setting SSL Verification
+
+#### Development/Testing
+```bash
+# In .env file
+SSL_VERIFY_PEER=false  # Default - works with Supabase
+```
+
+#### Production (Fly.io)
+```bash
+# Set via fly secrets
+fly secrets set SSL_VERIFY_PEER=false
+
+# Or to enable verification (may cause connection issues with Supabase)
+fly secrets set SSL_VERIFY_PEER=true
+```
+
+### Troubleshooting SSL Issues
+
+#### Connection Errors with SSL_VERIFY_PEER=true
+If you encounter errors like:
+```
+(DBConnection.ConnectionError) failed to connect: options cannot be combined: [{verify,verify_peer}, {cacerts,undefined}]
+```
+
+**Solution**: Set `SSL_VERIFY_PEER=false` (or leave unset) for Supabase connections.
+
+#### Certificate Verification Failures
+If you need certificate verification, ensure:
+1. Your environment has access to CA certificate bundles
+2. Custom certificates are properly configured
+3. Network policies allow certificate validation
+
+### Example Configurations
+
+#### Supabase (Recommended)
+```bash
+SUPABASE_DATABASE_URL=postgresql://postgres:[password]@[host]:5432/postgres
+SSL_VERIFY_PEER=false  # Or leave unset
+```
+
+#### Self-Managed PostgreSQL
+```bash
+DATABASE_URL=postgresql://user:pass@your-server:5432/database
+SSL_VERIFY_PEER=true  # Only if you have proper CA certificates
+```
+
+## Database Configuration
+
+The application uses the following database configuration:
+
+```elixir
+config :eventasaurus, EventasaurusApp.Repo,
+  url: System.get_env("SUPABASE_DATABASE_URL"),
+  database: "postgres",
+  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5"),
+  queue_target: 5000,
+  queue_interval: 30000,
+  ssl: true,
+  ssl_opts: [verify: ssl_verify]  # Controlled by SSL_VERIFY_PEER
+```
+
+## Deployment Checklist
+
+1. ✅ Set required environment variables
+2. ✅ Configure SSL settings for your database provider
+3. ✅ Verify database connectivity
+4. ✅ Check application logs for SSL warnings
+5. ✅ Test authentication flow
+6. ✅ Confirm Phoenix socket origin settings 


### PR DESCRIPTION
# Improve SSL Configuration and Add Deployment Documentation

### TL;DR

Update SSL verification settings for Supabase compatibility and add comprehensive deployment documentation.

### What changed?

- Changed default host from `example.com` to `eventasaur.us`
- Added `check_origin` configuration for secure WebSocket connections
- Reversed the SSL verification logic to default to `:verify_none` for Supabase compatibility
- Added warning logs when SSL verification is disabled
- Created detailed deployment documentation with environment variables, SSL configuration guidance, and troubleshooting tips

### How to test?

1. Verify the application connects to Supabase with the default SSL settings
2. Test WebSocket connections from the allowed origins
3. Try setting `SSL_VERIFY_PEER=true` to confirm the behavior changes
4. Review the deployment documentation for completeness

### Why make this change?

Supabase typically requires SSL verification to be disabled in containerized environments due to how it manages certificates. This change makes the application work seamlessly with Supabase by default while providing clear documentation on the security implications and options for different deployment scenarios. The added `check_origin` configuration also improves WebSocket security by restricting connections to trusted domains.