### PR TITLE
fixed maybe

### DIFF
--- a/lib/eventasaurus_app/auth/client.ex
+++ b/lib/eventasaurus_app/auth/client.ex
@@ -250,10 +250,10 @@ defmodule EventasaurusApp.Auth.Client do
   end
 
   @doc """
-  Create a user using admin API (bypasses email confirmation if configured).
+  Create a user using admin API with email confirmation required.
 
   This requires a service role key and is used for programmatic user creation
-  where we want to bypass the normal signup flow.
+  where we want to create accounts that require email confirmation for access.
 
   Returns {:ok, user_data} on success or {:error, reason} on failure.
   """
@@ -264,7 +264,7 @@ defmodule EventasaurusApp.Auth.Client do
       email: email,
       password: password,
       user_metadata: user_metadata,
-      email_confirm: true  # This bypasses email confirmation
+      email_confirm: false  # This requires email confirmation for account access
     })
 
     case HTTPoison.post(url, body, admin_headers()) do

--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -341,7 +341,7 @@ defmodule EventasaurusWeb.PublicEventLive do
   def handle_info({:registration_success, type, _name, email}, socket) do
     message = case type do
       :new_registration ->
-        "Welcome! You're now registered for #{socket.assigns.event.title}. Check your email for account verification instructions."
+        "Registration successful! You're now registered for #{socket.assigns.event.title}. Please check your email to activate your account."
       :existing_user_registered ->
         "Great! You're now registered for #{socket.assigns.event.title}."
     end
@@ -403,7 +403,7 @@ defmodule EventasaurusWeb.PublicEventLive do
   def handle_info({:vote_success, type, _name, email}, socket) do
     message = case type do
       :new_voter ->
-        "Thanks! Your vote has been recorded. Check your email for account verification instructions."
+        "Thanks! Your vote has been recorded. Please check your email to activate your account."
       :existing_user_voted ->
         "Great! Your vote has been recorded."
     end
@@ -486,7 +486,7 @@ defmodule EventasaurusWeb.PublicEventLive do
 
         message = case result_type do
           :new_voter ->
-            "All #{map_size(temp_votes)} votes saved successfully! You're now registered for #{socket.assigns.event.title}. Check your email to verify your account."
+            "All #{map_size(temp_votes)} votes saved successfully! You're now registered for #{socket.assigns.event.title}. Please check your email to activate your account."
           :existing_user_voted ->
             "All #{map_size(temp_votes)} votes saved successfully! You're registered for #{socket.assigns.event.title}."
         end


### PR DESCRIPTION
### TL;DR

Updated user registration flow to require email confirmation for new accounts.

### What changed?

- Modified the admin API user creation function to require email confirmation by changing `email_confirm: true` to `email_confirm: false`
- Updated the function documentation to reflect that email confirmation is now required rather than bypassed
- Revised user-facing messages across the application to clearly instruct users to check their email to activate their account

### How to test?

1. Register a new user for an event
2. Verify the updated confirmation message appears
3. Check that the user cannot access their account until confirming via email
4. Test the same flow for voting on an event
5. Confirm that bulk voting also shows the updated confirmation message

### Why make this change?

This change improves security by ensuring all new accounts verify their email address before gaining full access to the system. It also provides clearer instructions to users about the need to activate their accounts, which should reduce confusion and support requests from users who haven't completed the email verification step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated user-facing messages to consistently state "Please check your email to activate your account" after registration and voting actions.
- **Documentation**
  - Clarified documentation to indicate that new accounts now require email confirmation for activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->