### PR TITLE
migrate foriegn keys

### DIFF
--- a/lib/eventasaurus_app/auth/client.ex
+++ b/lib/eventasaurus_app/auth/client.ex
@@ -304,6 +304,27 @@ defmodule EventasaurusApp.Auth.Client do
   end
 
   @doc """
+  Delete a user using admin API.
+
+  Returns {:ok, %{}} on success or {:error, reason} on failure.
+  """
+  def admin_delete_user(user_id) do
+    url = "#{get_auth_url()}/admin/users/#{user_id}"
+
+    case HTTPoison.delete(url, admin_headers()) do
+      {:ok, %{status_code: 200}} ->
+        {:ok, %{}}
+
+      {:ok, %{status_code: code, body: response_body}} ->
+        error = Jason.decode!(response_body)
+        {:error, %{status: code, message: error["message"] || "User deletion failed"}}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  @doc """
   Get a user by email using admin API.
 
   Returns {:ok, user_data} on success or {:error, reason} on failure.

--- a/priv/repo/migrations/20250608104045_add_auth_users_foreign_key.exs
+++ b/priv/repo/migrations/20250608104045_add_auth_users_foreign_key.exs
@@ -1,0 +1,32 @@
+defmodule EventasaurusApp.Repo.Migrations.AddAuthUsersForeignKey do
+  use Ecto.Migration
+
+  def up do
+    # Since we can't create a direct FK between UUID and string,
+    # we'll use the official Supabase approach: database triggers
+
+    # Function to delete public user when auth user is deleted
+    execute """
+    CREATE OR REPLACE FUNCTION public.delete_user_on_auth_delete()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      DELETE FROM public.users WHERE supabase_id = OLD.id::text;
+      RETURN OLD;
+    END;
+    $$ LANGUAGE plpgsql SECURITY DEFINER;
+    """
+
+    # Trigger on auth.users deletion
+    execute """
+    CREATE TRIGGER on_auth_user_deleted
+      AFTER DELETE ON auth.users
+      FOR EACH ROW EXECUTE FUNCTION public.delete_user_on_auth_delete();
+    """
+  end
+
+  def down do
+    # Remove the trigger and function
+    execute "DROP TRIGGER IF EXISTS on_auth_user_deleted ON auth.users"
+    execute "DROP FUNCTION IF EXISTS public.delete_user_on_auth_delete()"
+  end
+end


### PR DESCRIPTION
### TL;DR

Added admin user deletion functionality and database triggers to maintain data integrity between auth and public users.

### What changed?

- Added `admin_delete_user/1` function to the Auth Client module that allows deleting users via the admin API
- Created a new migration that implements database triggers to automatically delete public users when their corresponding auth user is deleted
- Implemented a PostgreSQL function `delete_user_on_auth_delete()` that handles the cascading deletion
- Added a trigger `on_auth_user_deleted` that executes after a user is deleted from the auth.users table

### How to test?

1. Delete a user through the admin API using `EventasaurusApp.Auth.Client.admin_delete_user(user_id)`
2. Verify that the user is removed from both the auth.users table and the public.users table
3. Check that no orphaned records remain in the public.users table

### Why make this change?

This change ensures data integrity between the auth.users and public.users tables by automatically removing corresponding public user records when auth users are deleted. Since we can't use traditional foreign keys between UUID and string types, database triggers provide a robust solution to maintain referential integrity and prevent orphaned records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for administrators to delete users directly.
- **Chores**
  - Improved database integrity by ensuring related user records are automatically removed when an associated user is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->