### PR TITLE
small fix

### DIFF
--- a/lib/eventasaurus_web/controllers/event_social_card_controller.ex
+++ b/lib/eventasaurus_web/controllers/event_social_card_controller.ex
@@ -59,7 +59,7 @@ defmodule EventasaurusWeb.EventSocialCardController do
                     SvgConverter.cleanup_temp_file(png_path)
 
                     conn
-                    |> put_resp_content_type("image/png")
+                    |> put_resp_header("content-type", "image/png")
                     |> put_resp_header("cache-control", "public, max-age=31536000")  # Cache for 1 year since hash ensures freshness
                     |> put_resp_header("etag", "\"#{final_hash}\"")
                     |> send_resp(200, png_data)

--- a/lib/eventasaurus_web/router.ex
+++ b/lib/eventasaurus_web/router.ex
@@ -18,6 +18,10 @@ defmodule EventasaurusWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :image do
+    plug :accepts, ["png", "jpg", "jpeg", "gif", "webp"]
+  end
+
   # Routes that require authentication
   pipeline :authenticated do
     plug :require_authenticated_user
@@ -110,7 +114,7 @@ defmodule EventasaurusWeb.Router do
 
   # Public social card generation (no auth required)
   scope "/events", EventasaurusWeb do
-    pipe_through :browser
+    pipe_through :image
 
     # Cache-busting social card generation (by slug with hash)
     get "/:slug/social-card-:hash/*rest", EventSocialCardController, :generate_card_by_slug, as: :social_card_cached


### PR DESCRIPTION
### TL;DR

Enhanced image URL handling to support local static files in social card generation.

### What changed?

- Updated `validate_image_url` to accept local static file paths (e.g., `/images/events/general/metaverse.png`)
- Improved image extension detection to support format indicators in query params and known image services
- Added security checks to ensure local paths are within allowed static directories
- Modified `get_local_image_path` to handle both external URLs and local static files
- Changed router to use an `:image` pipeline with appropriate content types for social card routes
- Fixed content-type header in the social card controller

### How to test?

1. Test social card generation with local static images (e.g., `/images/events/general/metaverse.png`)
2. Verify that external image URLs still work, including those from Unsplash and Cloudinary
3. Confirm that invalid image paths are properly rejected
4. Check that social cards are served with the correct content-type headers

### Why make this change?

This change improves performance and reliability by allowing the use of local static images instead of always requiring external URLs. It also enhances security by validating local paths and adds support for more image URL formats from popular services, making the social card generation more flexible and robust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for using both external image URLs and local static image files when generating social cards.
- **Improvements**
  - Enhanced image URL validation to recognize more image formats and popular image hosting services.
  - Updated social card endpoints to accept image-specific request formats for improved compatibility.
- **Bug Fixes**
  - Improved handling of response headers when serving PNG images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->