### PR TITLE
completely working

### DIFF
--- a/lib/eventasaurus_web/components/calendar_component.ex
+++ b/lib/eventasaurus_web/components/calendar_component.ex
@@ -37,7 +37,7 @@ defmodule EventasaurusWeb.CalendarComponent do
     {:ok, socket}
   end
 
-  @impl true
+    @impl true
   def handle_event("toggle_date", %{"date" => date_string}, socket) do
     case Date.from_iso8601(date_string) do
       {:ok, date} ->
@@ -58,7 +58,7 @@ defmodule EventasaurusWeb.CalendarComponent do
             component_id: socket.assigns.id || "calendar"
           })
 
-        # Send the updated dates to the parent
+        # Send the updated dates to the parent LiveView
         send(self(), {:selected_dates_changed, updated_dates})
 
         {:noreply, socket}


### PR DESCRIPTION
### TL;DR

Added support for editing date poll options in the event edit form.

### What changed?

- Enhanced the event edit form to load existing date poll options when editing an event
- Added functionality to save selected poll dates when updating an event
- Implemented `handle_date_polling_update` helper function to manage date poll creation, updates, and state changes
- Improved the calendar component's comment to clarify it sends updates to the parent LiveView
- Fixed indentation in a few places

### How to test?

1. Edit an existing event with date polling enabled
2. Verify that previously selected poll dates are loaded in the calendar
3. Add or remove dates from the poll and save the event
4. Confirm that enabling/disabling date polling correctly updates the event state
5. Verify that date options are properly saved and displayed after updates

### Why make this change?

Previously, users couldn't edit date poll options after creating an event. This change allows event organizers to modify poll dates even after the initial creation, providing more flexibility in event planning and accommodating changes in scheduling needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for managing and updating date polling options when editing events, including enabling/disabling date polling and selecting poll dates.

- **Documentation**
  - Improved and clarified comments in the calendar and event editing components for better understanding of data flow and logic.

- **Style**
  - Minor formatting adjustments for code consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->