### PR TITLE
small validation changes

### DIFF
--- a/lib/eventasaurus_app/events/event.ex
+++ b/lib/eventasaurus_app/events/event.ex
@@ -34,6 +34,9 @@ defmodule EventasaurusApp.Events.Event do
       default: :minimal
     field :theme_customizations, :map, default: %{}
 
+    # Virtual field for date polling validation
+    field :selected_poll_dates, :string, virtual: true
+
     belongs_to :venue, EventasaurusApp.Venues.Venue
 
     many_to_many :users, EventasaurusApp.Accounts.User,
@@ -49,7 +52,7 @@ defmodule EventasaurusApp.Events.Event do
     event
     |> cast(attrs, [:title, :tagline, :description, :start_at, :ends_at, :timezone,
                    :visibility, :slug, :cover_image_url, :venue_id, :external_image_data,
-                   :theme, :theme_customizations, :state])
+                   :theme, :theme_customizations, :state, :selected_poll_dates])
     |> validate_required([:title, :start_at, :timezone, :visibility])
     |> validate_length(:title, min: 3, max: 100)
     |> validate_length(:tagline, max: 255)

--- a/lib/eventasaurus_web/components/event_components.ex
+++ b/lib/eventasaurus_web/components/event_components.ex
@@ -310,8 +310,12 @@ defmodule EventasaurusWeb.EventComponents do
                   />
                   <!-- Hidden fields to store selected dates -->
                   <input type="hidden" name="event[selected_poll_dates]" id={"#{@id}-selected-dates"} value={encode_selected_dates(@form_data)} />
-                  <!-- Validation error container -->
-                  <div id="date-selection-error" class="hidden mt-2"></div>
+                  <!-- Validation error display -->
+                  <%= if f[:selected_poll_dates] && f[:selected_poll_dates].errors != [] do %>
+                    <div class="mt-2 text-sm text-red-600" phx-feedback-for="event[selected_poll_dates]">
+                      <%= Enum.map(f[:selected_poll_dates].errors, fn {msg, _} -> msg end) |> Enum.join(", ") %>
+                    </div>
+                  <% end %>
                 </div>
 
                 <!-- Time inputs for polling -->
@@ -473,7 +477,7 @@ defmodule EventasaurusWeb.EventComponents do
 
             <!-- Description & Details -->
             <div class="mb-4">
-              <.input field={f[:description]} type="textarea" label="Description" required class="text-sm" />
+              <.input field={f[:description]} type="textarea" label="Description" class="text-sm" />
             </div>
 
             <!-- Additional Options (compact) -->


### PR DESCRIPTION
### TL;DR

Added validation for date polling to ensure at least 2 dates are selected when date polling is enabled.

### What changed?

- Added a virtual field `selected_poll_dates` to the Event schema to support validation
- Implemented validation logic in both new and edit event forms to check for at least 2 dates when date polling is enabled
- Added proper error display for date polling validation in the UI
- Made the description field optional by removing the `required` attribute

### How to test?

1. Create a new event and enable date polling
2. Try to submit the form without selecting any dates or with only one date selected
3. Verify that an error message appears requiring at least 2 dates
4. Select 2+ dates and verify the form submits successfully
5. Test the same validation in the edit event form

### Why make this change?

Date polling requires at least two options to be meaningful. This validation ensures users provide sufficient date options when enabling the polling feature, preventing the creation of polls with insufficient choices. The change also improves the user experience by providing clear feedback when validation fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to ensure that at least two dates are selected when date polling is enabled for events.

- **Bug Fixes**
  - The event form now displays validation errors for poll date selection directly to users.

- **Improvements**
  - The event description field is now optional instead of required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->