### PR TITLE
date fixes

### DIFF
--- a/lib/eventasaurus_web/controllers/event_html/show.html.heex
+++ b/lib/eventasaurus_web/controllers/event_html/show.html.heex
@@ -92,12 +92,12 @@
               <div>
                 <h3 class="font-semibold text-gray-900 mb-1">When</h3>
                 <p class="text-gray-700">
-                  <%= Calendar.strftime(@event.start_at, "%A, %B %d, %Y") %>
+                  <%= EventasaurusWeb.TimezoneHelpers.convert_to_timezone(@event.start_at, @event.timezone) |> Calendar.strftime("%A, %B %d, %Y") %>
                 </p>
                 <p class="text-gray-600 text-sm">
-                  <%= Calendar.strftime(@event.start_at, "%I:%M %p") |> String.replace(" 0", " ") %>
+                  <%= EventasaurusWeb.TimezoneHelpers.convert_to_timezone(@event.start_at, @event.timezone) |> Calendar.strftime("%I:%M %p") |> String.replace(" 0", " ") %>
                   <%= if @event.ends_at do %>
-                    - <%= Calendar.strftime(@event.ends_at, "%I:%M %p") |> String.replace(" 0", " ") %>
+                    - <%= EventasaurusWeb.TimezoneHelpers.convert_to_timezone(@event.ends_at, @event.timezone) |> Calendar.strftime("%I:%M %p") |> String.replace(" 0", " ") %>
                   <% end %>
                   <%= if @event.timezone do %>(<%= @event.timezone %>)<% end %>
                 </p>

--- a/lib/eventasaurus_web/helpers/timezone_helpers.ex
+++ b/lib/eventasaurus_web/helpers/timezone_helpers.ex
@@ -57,6 +57,19 @@ defmodule EventasaurusWeb.TimezoneHelpers do
   end
 
   @doc """
+  Convert a UTC datetime to the specified timezone.
+  Returns the converted datetime or the original if conversion fails.
+  """
+  def convert_to_timezone(datetime, timezone) when is_binary(timezone) do
+    case DateTime.shift_zone(datetime, timezone) do
+      {:ok, converted} -> converted
+      {:error, _} -> datetime
+    end
+  end
+
+  def convert_to_timezone(datetime, _), do: datetime
+
+  @doc """
   Format a timezone string with its UTC offset for display purposes.
   Example: "America/New_York (UTC-05:00)"
   """

--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -536,8 +536,8 @@ defmodule EventasaurusWeb.PublicEventLive do
           <!-- Date/time and main info -->
           <div class="flex items-start gap-4 mb-8">
             <div class="bg-white border border-gray-200 rounded-lg p-3 w-16 h-16 flex flex-col items-center justify-center text-center font-medium shadow-sm">
-              <div class="text-xs text-gray-500 uppercase tracking-wide"><%= Calendar.strftime(@event.start_at, "%b") %></div>
-              <div class="text-xl font-semibold text-gray-900"><%= Calendar.strftime(@event.start_at, "%d") %></div>
+              <div class="text-xs text-gray-500 uppercase tracking-wide"><%= EventasaurusWeb.TimezoneHelpers.convert_to_timezone(@event.start_at, @event.timezone) |> Calendar.strftime("%b") %></div>
+              <div class="text-xl font-semibold text-gray-900"><%= EventasaurusWeb.TimezoneHelpers.convert_to_timezone(@event.start_at, @event.timezone) |> Calendar.strftime("%d") %></div>
             </div>
             <div>
               <h1 class="text-3xl lg:text-4xl font-bold text-gray-900 mb-4 leading-tight"><%= @event.title %></h1>
@@ -549,9 +549,9 @@ defmodule EventasaurusWeb.PublicEventLive do
               <div class="mb-4">
                 <h3 class="font-semibold text-gray-900 mb-1">When</h3>
                 <div class="text-lg text-gray-700 font-medium">
-                  <%= Calendar.strftime(@event.start_at, "%A, %B %d · %I:%M %p") |> String.replace(" 0", " ") %>
+                  <%= EventasaurusWeb.TimezoneHelpers.convert_to_timezone(@event.start_at, @event.timezone) |> Calendar.strftime("%A, %B %d · %I:%M %p") |> String.replace(" 0", " ") %>
                   <%= if @event.ends_at do %>
-                    - <%= Calendar.strftime(@event.ends_at, "%I:%M %p") |> String.replace(" 0", " ") %>
+                    - <%= EventasaurusWeb.TimezoneHelpers.convert_to_timezone(@event.ends_at, @event.timezone) |> Calendar.strftime("%I:%M %p") |> String.replace(" 0", " ") %>
                   <% end %>
                   <span class="text-gray-500 ml-1"><%= @event.timezone %></span>
                 </div>


### PR DESCRIPTION
### TL;DR

Fixed event time display to properly show times in the event's timezone instead of UTC.

### What changed?

- Added a new `convert_to_timezone/2` helper function in `TimezoneHelpers` module that converts a UTC datetime to a specified timezone
- Updated the event display templates to use this helper function when displaying dates and times
- Applied the timezone conversion in both the controller-rendered event page and the LiveView public event page

### How to test?

1. Create an event with a timezone different from UTC
2. View the event page and verify that the displayed dates and times match the event's timezone
3. Test with events in various timezones to ensure proper conversion
4. Verify that the date/time display format remains consistent

### Why make this change?

Previously, event times were being displayed in UTC regardless of the event's timezone setting. This was confusing for users who expected to see times in the event's local timezone. This change ensures that all displayed dates and times are properly converted to the event's specified timezone, providing a more accurate and user-friendly experience.