### PR TITLE
small ui fixes

### DIFF
--- a/test/eventasaurus_web/live/event_live/calendar_integration_test.exs
+++ b/test/eventasaurus_web/live/event_live/calendar_integration_test.exs
@@ -227,8 +227,8 @@ defmodule EventasaurusWeb.EventLive.CalendarIntegrationTest do
       assert has_element?(view, "[data-test-id='event-form']")
 
       # Selected dates should still be visible and selected
-      assert has_element?(view, "button[phx-value-date='#{Date.to_iso8601(date1)}'][aria-pressed='aria-pressed']")
-      assert has_element?(view, "button[phx-value-date='#{Date.to_iso8601(date2)}'][aria-pressed='aria-pressed']")
+      assert has_element?(view, "button[phx-value-date='#{Date.to_iso8601(date1)}'][aria-pressed='true']")
+      assert has_element?(view, "button[phx-value-date='#{Date.to_iso8601(date2)}'][aria-pressed='true']")
       assert has_element?(view, "[role='status']", "Selected dates (2):")
     end
 
@@ -324,7 +324,7 @@ defmodule EventasaurusWeb.EventLive.CalendarIntegrationTest do
       |> render_click()
 
       # Verify the date appears as selected in the calendar
-      assert has_element?(view, "button[phx-value-date='#{date_string}'][aria-pressed='aria-pressed']")
+      assert has_element?(view, "button[phx-value-date='#{date_string}'][aria-pressed='true']")
 
       # Verify it appears in the selected dates summary
       formatted_date = Calendar.strftime(future_date, "%b %d")


### PR DESCRIPTION
### TL;DR

Refactored calendar component to improve keyboard navigation and accessibility.

### What changed?

- Extracted date toggling logic into a new private helper function `toggle_date_in_socket` to reduce code duplication
- Improved keyboard navigation handling by directly toggling dates on Enter/Space key presses instead of sending messages
- Fixed accessibility by ensuring `aria-pressed` attribute has proper string values ("true"/"false") instead of boolean values
- Simplified the key navigation event handler with a clearer case statement structure

### How to test?

1. Navigate through the calendar using arrow keys (left, right, up, down)
2. Select/deselect dates using Enter or Space keys
3. Verify that screen readers correctly announce selected dates
4. Confirm that all existing calendar functionality works as expected

### Why make this change?

This refactoring improves code maintainability by reducing duplication and makes the calendar component more accessible to keyboard and screen reader users. The proper implementation of ARIA attributes ensures better compatibility with assistive technologies.