### PR TITLE
small fixes for orders

### DIFF
--- a/lib/eventasaurus/events/order.ex
+++ b/lib/eventasaurus/events/order.ex
@@ -66,7 +66,7 @@ defmodule EventasaurusApp.Events.Order do
   def can_cancel?(%__MODULE__{status: "pending"}), do: true
   def can_cancel?(_), do: false
 
-  def can_refund?(%__MODULE__{status: "confirmed"}), do: true
-  def can_refund?(%__MODULE__{status: "canceled"}), do: true
+  def can_refund?(%__MODULE__{status: "confirmed", payment_reference: ref}) when not is_nil(ref), do: true
+  def can_refund?(%__MODULE__{status: "canceled", payment_reference: ref}) when not is_nil(ref), do: true
   def can_refund?(_), do: false
 end

--- a/lib/eventasaurus/events/ticket.ex
+++ b/lib/eventasaurus/events/ticket.ex
@@ -37,9 +37,6 @@ defmodule EventasaurusApp.Events.Ticket do
     ends_at = get_field(changeset, :ends_at)
 
     cond do
-      is_nil(starts_at) && ends_at ->
-        add_error(changeset, :starts_at, "must be present when ends_at is set")
-
       starts_at && ends_at && DateTime.compare(starts_at, ends_at) != :lt ->
         add_error(changeset, :ends_at, "must be after start time")
 

--- a/lib/eventasaurus_app/ticketing.ex
+++ b/lib/eventasaurus_app/ticketing.ex
@@ -322,7 +322,7 @@ defmodule EventasaurusApp.Ticketing do
   def create_order(%User{} = user, %Ticket{} = ticket, attrs \\ %{}) do
     quantity = Map.get(attrs, :quantity, 1)
 
-        # Use transaction with row locking to prevent overselling
+            # Use transaction with row locking to prevent overselling
     case Repo.transaction(fn ->
       # Lock the ticket row to prevent concurrent modifications
       locked_ticket = Repo.get!(Ticket, ticket.id, lock: "FOR UPDATE")
@@ -333,11 +333,12 @@ defmodule EventasaurusApp.Ticketing do
         maybe_broadcast_order_update(order, :created)
         order
       else
+        {:error, reason} -> Repo.rollback(reason)
         error -> Repo.rollback(error)
       end
     end) do
       {:ok, order} -> {:ok, order}
-      {:error, error} -> error
+      {:error, error} -> {:error, error}
     end
   end
 

--- a/test/eventasaurus_app/events/order_test.exs
+++ b/test/eventasaurus_app/events/order_test.exs
@@ -261,8 +261,10 @@ defmodule EventasaurusApp.Events.OrderTest do
 
     test "can_refund?/1" do
       refute Order.can_refund?(%Order{status: "pending"})
-      assert Order.can_refund?(%Order{status: "confirmed"})
-      assert Order.can_refund?(%Order{status: "canceled"})  # Canceled orders can be refunded if payment was captured
+      refute Order.can_refund?(%Order{status: "confirmed", payment_reference: nil})  # No payment captured
+      assert Order.can_refund?(%Order{status: "confirmed", payment_reference: "pi_123"})  # Payment captured
+      refute Order.can_refund?(%Order{status: "canceled", payment_reference: nil})  # No payment captured
+      assert Order.can_refund?(%Order{status: "canceled", payment_reference: "pi_123"})  # Payment captured
       refute Order.can_refund?(%Order{status: "refunded"})
     end
   end


### PR DESCRIPTION
### TL;DR

Updated order refund logic to check for payment references and fixed transaction error handling.

### What changed?

- Modified `can_refund?/1` in the Order module to only allow refunds when a payment reference exists
- Removed unnecessary validation in the Ticket module that required starts_at when ends_at is set
- Improved error handling in the `create_order/3` function to properly handle and return errors from transactions
- Updated tests to verify the new refund logic with and without payment references

### How to test?

1. Verify that orders can only be refunded when they have a payment reference:
   - Create orders in "confirmed" and "canceled" states with and without payment references
   - Confirm that only orders with payment references can be refunded

2. Test the transaction error handling in order creation:
   - Attempt to create orders with invalid data
   - Verify that errors are properly returned and not lost in the transaction

### Why make this change?

This change prevents attempting to refund orders that don't have an associated payment reference, which would cause errors when trying to process refunds through payment providers. It also improves error handling during order creation to ensure that specific error reasons are properly propagated to the caller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved refund eligibility checks to ensure orders can only be refunded if payment has been captured.
	- Simplified ticket availability validation by removing unnecessary requirements for start and end times.

- **Tests**
	- Updated refund eligibility tests to align with the new payment capture requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->