### PR TITLE
final edits for edit and nw

### DIFF
--- a/lib/eventasaurus_web/components/event_components.ex
+++ b/lib/eventasaurus_web/components/event_components.ex
@@ -152,15 +152,14 @@ defmodule EventasaurusWeb.EventComponents do
   @doc """
   Event Setup Path Selector Component
 
-  Presents four distinct setup modes for event creation:
+  Presents three distinct setup modes for event creation:
   1. Planning Stage (Polling) - for users still deciding on date
-  2. Confirmed (No Tickets) - for simple event publishing
-  3. Ticketed (Confirmed with Tickets) - for immediate ticket sales
-  4. Threshold-Based Pre-Sale - for demand validation before committing
+  2. Confirmed (Free/Ticketed) - for standard event publishing with optional ticketing
+  3. Threshold-Based Pre-Sale - for demand validation before committing
   """
   attr :selected_path, :string, default: "confirmed", doc: "the currently selected setup path"
   attr :mode, :string, default: "full", doc: "display mode: 'full' for new events, 'compact' for edit"
-  attr :show_stage_transitions, :boolean, default: false, doc: "whether to show full selector in edit mode"
+  attr :show_stage_transitions, :boolean, default: false, values: [true, false], doc: "whether to show full selector in edit mode"
 
   def event_setup_path_selector(assigns) do
     ~H"""
@@ -400,7 +399,7 @@ defmodule EventasaurusWeb.EventComponents do
   attr :enable_date_polling, :boolean, default: false, doc: "whether date polling is enabled"
   attr :setup_path, :string, default: "confirmed", doc: "the selected setup path: polling, confirmed, or threshold"
   attr :mode, :string, default: "full", doc: "display mode: 'full' for new events, 'compact' for edit"
-  attr :show_stage_transitions, :boolean, default: false, doc: "whether to show full selector in edit mode"
+  attr :show_stage_transitions, :boolean, default: false, values: [true, false], doc: "whether to show full selector in edit mode"
   # Ticketing-related attributes
   attr :tickets, :list, default: [], doc: "list of existing tickets for the event"
 
@@ -785,7 +784,7 @@ defmodule EventasaurusWeb.EventComponents do
                   <input type="hidden" name="event[requires_threshold]" value="false" />
                 <% end %>
 
-                <%= if @setup_path in ["confirmed", "ticketed", "threshold"] do %>
+                <%= if @setup_path in ["confirmed", "threshold"] do %>
                 <!-- Tickets Management Section -->
                 <div class="space-y-4" id="tickets-section">
                   <div class="flex items-center justify-between">

--- a/lib/eventasaurus_web/live/event_live/edit.ex
+++ b/lib/eventasaurus_web/live/event_live/edit.ex
@@ -16,6 +16,8 @@ defmodule EventasaurusWeb.EventLive.Edit do
   alias EventasaurusWeb.Services.DefaultImagesService
   alias EventasaurusApp.Ticketing
 
+  @valid_setup_paths ~w[polling confirmed threshold]
+
   @impl true
   def mount(%{"slug" => slug}, _session, socket) do
     event = Events.get_event_by_slug(slug)
@@ -107,9 +109,9 @@ defmodule EventasaurusWeb.EventLive.Edit do
               "polling_deadline" => if(event.polling_deadline, do: DateTime.to_iso8601(event.polling_deadline), else: ""),
               "polling_deadline_date" => polling_deadline_date,
               "polling_deadline_time" => polling_deadline_time,
-              "is_ticketed" => event.is_ticketed,
+              "is_ticketed" => to_string(event.is_ticketed),
               "setup_path" => setup_path,
-              "requires_threshold" => Map.get(event, :requires_threshold, false)
+              "requires_threshold" => to_string(Map.get(event, :requires_threshold, false))
             }
 
             # Load existing tickets for the event
@@ -185,23 +187,31 @@ defmodule EventasaurusWeb.EventLive.Edit do
   # ========== Event Handlers ==========
 
   @impl true
-  def handle_event("select_setup_path", %{"path" => path}, socket) do
+  def handle_event("select_setup_path", %{"path" => path}, socket) when path in @valid_setup_paths do
     # Update form_data based on the selected path
-    form_data = socket.assigns.form_data
-    |> Map.put("setup_path", path)
-    |> Map.put("enable_date_polling", path == "polling")
-    |> Map.put("is_ticketed", path in ["confirmed", "threshold"])
-    |> Map.put("requires_threshold", path == "threshold")
+    form_data =
+      socket.assigns.form_data
+      |> Map.put("setup_path", path)
+      |> Map.put("enable_date_polling", to_string(path == "polling"))
+      |> Map.put("is_ticketed", to_string(path in ["confirmed", "threshold"]))
+      |> Map.put("requires_threshold", to_string(path == "threshold"))
 
     # Update the socket with the new path and form data, and hide the transition selector
-    socket = socket
-    |> assign(:setup_path, path)
-    |> assign(:enable_date_polling, path == "polling")
-    |> assign(:form_data, form_data)
-    |> assign(:show_stage_transitions, false)
+    socket =
+      socket
+      |> assign(:setup_path, path)
+      |> assign(:enable_date_polling, path == "polling")
+      |> assign(:is_ticketed, path in ["confirmed", "threshold"])
+      |> assign(:requires_threshold, path == "threshold")
+      |> assign(:form_data, form_data)
+      |> assign(:show_stage_transitions, false)
+      |> maybe_reset_ticketing(path)
 
     {:noreply, socket}
   end
+
+  def handle_event("select_setup_path", _params, socket),
+    do: {:noreply, socket}  # ignore unknown values
 
   @impl true
   def handle_event("show_stage_transitions", _params, socket) do
@@ -214,22 +224,30 @@ defmodule EventasaurusWeb.EventLive.Edit do
   end
 
   @impl true
-  def handle_event("transition_to_stage", %{"stage" => stage}, socket) do
+  def handle_event("transition_to_stage", %{"stage" => stage}, socket) when stage in @valid_setup_paths do
     # Update form_data and socket state for the new stage
-    form_data = socket.assigns.form_data
-    |> Map.put("setup_path", stage)
-    |> Map.put("enable_date_polling", stage == "polling")
-    |> Map.put("is_ticketed", stage in ["threshold"])
-    |> Map.put("requires_threshold", stage == "threshold")
+    form_data =
+      socket.assigns.form_data
+      |> Map.put("setup_path", stage)
+      |> Map.put("enable_date_polling", to_string(stage == "polling"))
+      |> Map.put("is_ticketed", to_string(stage in ["confirmed", "threshold"]))
+      |> Map.put("requires_threshold", to_string(stage == "threshold"))
 
-    socket = socket
-    |> assign(:setup_path, stage)
-    |> assign(:enable_date_polling, stage == "polling")
-    |> assign(:form_data, form_data)
-    |> assign(:show_stage_transitions, false)
+    socket =
+      socket
+      |> assign(:setup_path, stage)
+      |> assign(:enable_date_polling, stage == "polling")
+      |> assign(:is_ticketed, stage in ["confirmed", "threshold"])
+      |> assign(:requires_threshold, stage == "threshold")
+      |> assign(:form_data, form_data)
+      |> assign(:show_stage_transitions, false)
+      |> maybe_reset_ticketing(stage)
 
     {:noreply, socket}
   end
+
+  def handle_event("transition_to_stage", _params, socket),
+    do: {:noreply, socket}  # ignore unknown values
 
   @impl true
   def handle_event("validate", %{"event" => event_params}, socket) do
@@ -1294,6 +1312,16 @@ defmodule EventasaurusWeb.EventLive.Edit do
           end
       end
     end
+  end
+
+  # Helper — clears ticket state unless the path is ticket-centric
+  defp maybe_reset_ticketing(socket, path) when path in ["confirmed", "threshold"], do: socket
+  defp maybe_reset_ticketing(socket, _path) do
+    socket
+    |> assign(:tickets, [])
+    |> assign(:show_ticket_modal, false)
+    |> assign(:ticket_form_data, %{})
+    |> assign(:editing_ticket_index, nil)
   end
 
   # Validation helper for flexible pricing


### PR DESCRIPTION
### TL;DR

Simplified event setup paths by consolidating ticketed and non-ticketed confirmed events into a single path.

### What changed?

- Reduced event setup paths from four to three by merging "Confirmed (No Tickets)" and "Ticketed" into a single "Confirmed (Free/Ticketed)" option
- Added proper type validation for setup path values with `@valid_setup_paths` constant
- Fixed boolean handling in form data by converting boolean values to strings
- Added `maybe_reset_ticketing/2` helper function to clear ticket state when switching to non-ticketing paths
- Added proper error handling for invalid setup path selections
- Updated attribute documentation to include valid values where appropriate

### How to test?

1. Create a new event and verify the simplified setup path options
2. Edit an existing event and test transitioning between different setup paths
3. Verify that ticketing information is properly preserved or reset when switching between paths
4. Test with invalid path values to ensure proper error handling

### Why make this change?

The previous four-path system created unnecessary complexity for users. By consolidating the confirmed event paths, we've simplified the user experience while maintaining all the same functionality. The improved type handling and validation also prevents potential errors when processing form data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified event setup options to three modes: Polling, Confirmed, and Threshold.
- **Bug Fixes**
	- Improved handling of invalid or unknown setup paths to prevent errors.
- **Refactor**
	- Standardized internal handling of setup path selection and ticket management for consistency across event creation and editing.
- **Documentation**
	- Updated user-facing descriptions to reflect the new setup modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->