### PR TITLE
gix dev problems

### DIFF
--- a/lib/eventasaurus/application.ex
+++ b/lib/eventasaurus/application.ex
@@ -8,7 +8,7 @@ defmodule Eventasaurus.Application do
   @impl true
   def start(_type, _args) do
     # Load environment variables from .env file if in dev/test environment
-    if Mix.env() in [:dev, :test] do
+    if Application.get_env(:eventasaurus, :environment) in [:dev, :test] do
       # Simple approach to load .env file
       case File.read(Path.expand(".env")) do
         {:ok, body} ->
@@ -29,7 +29,7 @@ defmodule Eventasaurus.Application do
     IO.puts("DEBUG - Google Maps API key loaded: #{if api_key, do: "YES", else: "NO"}")
 
     # Debug Stripe environment variables (dev/test only)
-    if Mix.env() in [:dev, :test] do
+    if Application.get_env(:eventasaurus, :environment) in [:dev, :test] do
       stripe_client_id = System.get_env("STRIPE_CLIENT_ID")
       stripe_secret = System.get_env("STRIPE_SECRET_KEY")
       IO.puts("DEBUG - Stripe Client ID loaded: #{if stripe_client_id, do: "YES", else: "NO"}")


### PR DESCRIPTION
### TL;DR

Replace `Mix.env()` with `Application.get_env(:eventasaurus, :environment)` for environment detection.

### What changed?

Modified the environment detection logic in `application.ex` to use `Application.get_env(:eventasaurus, :environment)` instead of `Mix.env()` in two places:
1. When determining whether to load environment variables from the `.env` file
2. When deciding whether to output debug information for Stripe environment variables

### How to test?

1. Ensure the application still loads environment variables correctly in development and test environments
2. Verify that debug output for Google Maps API key and Stripe credentials still appears in dev/test environments
3. Confirm that production environment behavior remains unchanged

### Why make this change?

Using `Application.get_env(:eventasaurus, :environment)` instead of `Mix.env()` is more flexible and follows best practices for runtime configuration. This approach allows environment settings to be configured at runtime rather than compile time, making the application more adaptable to different deployment scenarios and easier to configure in production environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the method for detecting the current environment to use a custom application configuration instead of the build environment. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->