### PR TITLE
small fix

### DIFF
--- a/lib/eventasaurus/application.ex
+++ b/lib/eventasaurus/application.ex
@@ -8,7 +8,8 @@ defmodule Eventasaurus.Application do
   @impl true
   def start(_type, _args) do
     # Load environment variables from .env file if in dev/test environment
-    if Application.get_env(:eventasaurus, :environment) in [:dev, :test] do
+    env = Application.get_env(:eventasaurus, :environment, :prod)
+    if env in [:dev, :test] do
       # Simple approach to load .env file
       case File.read(Path.expand(".env")) do
         {:ok, body} ->
@@ -29,7 +30,7 @@ defmodule Eventasaurus.Application do
     IO.puts("DEBUG - Google Maps API key loaded: #{if api_key, do: "YES", else: "NO"}")
 
     # Debug Stripe environment variables (dev/test only)
-    if Application.get_env(:eventasaurus, :environment) in [:dev, :test] do
+    if env in [:dev, :test] do
       stripe_client_id = System.get_env("STRIPE_CLIENT_ID")
       stripe_secret = System.get_env("STRIPE_SECRET_KEY")
       IO.puts("DEBUG - Stripe Client ID loaded: #{if stripe_client_id, do: "YES", else: "NO"}")


### PR DESCRIPTION
### TL;DR

Improved environment variable handling in the application startup process.

### What changed?

- Added a default value of `:prod` when retrieving the application environment
- Cached the environment value in a variable to avoid duplicate lookups
- Reused the cached environment variable in the Stripe debug section

### How to test?

1. Start the application in different environments (dev, test, prod)
2. Verify that environment variables are loaded correctly from the .env file in dev/test environments
3. Confirm that debug messages for Google Maps API and Stripe credentials appear only in dev/test environments

### Why make this change?

This change improves code efficiency by avoiding redundant environment lookups and adds a safety default of `:prod` when the environment isn't explicitly set. This ensures the application behaves predictably in all deployment scenarios, particularly in production where the environment might not be explicitly configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency by reusing the application environment setting, reducing redundant environment checks. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->