### PR TITLE
css busting changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,8 @@ ENV MIX_ENV="prod"
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/eventasaurus ./
 
-# Also copy static images from the build stage
-COPY --from=builder --chown=nobody:root /app/priv/static/images ./priv/static/images
+# Also copy all compiled static assets from the build stage (including CSS, JS, and images)
+COPY --from=builder --chown=nobody:root /app/priv/static ./priv/static
 
 USER nobody
 


### PR DESCRIPTION
### TL;DR

Copy all static assets in Docker build instead of just images.

### What changed?

Modified the Dockerfile to copy all compiled static assets (`/app/priv/static`) from the builder stage to the final image, rather than just copying the images directory (`/app/priv/static/images`). This ensures CSS, JavaScript, and other static assets are included in the final Docker image.

### How to test?

1. Build the Docker image with `docker build -t eventasaurus .`
2. Run the container and verify that all static assets (CSS, JS, images) are properly loaded
3. Check that the application UI renders correctly with all styles and functionality

### Why make this change?

The previous configuration only copied image files to the final Docker image, which would cause missing CSS and JavaScript assets in the deployed application. This change ensures the complete set of compiled static assets is available in the production container, fixing potential UI and functionality issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to include all static assets (CSS, JavaScript, images, etc.) in the final runtime image, ensuring complete static content is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->