### PR TITLE
fixing stuff

### DIFF
--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -496,6 +496,8 @@ defmodule EventasaurusWeb.PublicEventLive do
 
   def handle_info({:registration_success, type, _name, _email}, socket) do
     message = case type do
+      :new_registration -> "Successfully registered for #{socket.assigns.event.title}! Please check your email for a magic link to create your account."
+      :existing_user_registered -> "Successfully registered for #{socket.assigns.event.title}!"
       :registered -> "Successfully registered for #{socket.assigns.event.title}!"
       :already_registered -> "You are already registered for this event."
     end


### PR DESCRIPTION
### TL;DR

Added new registration success messages for different user registration scenarios.

### What changed?

Added two new case patterns in the `handle_info` function for registration success messages:
- `:new_registration` - For users who need to create an account
- `:existing_user_registered` - For existing users who register for an event

### How to test?

1. Register for an event as a new user and verify you see the message about checking your email for a magic link
2. Register for an event as an existing user and verify you see the success message without the account creation instructions
3. Test the existing `:registered` and `:already_registered` cases to ensure they still work correctly

### Why make this change?

To provide more specific feedback to users based on their registration status. New users need instructions about creating an account, while existing users only need confirmation of their registration. This improves the user experience by providing contextually appropriate information.