### PR TITLE
last bug

### DIFF
--- a/lib/eventasaurus_web/controllers/settings_html/index.html.heex
+++ b/lib/eventasaurus_web/controllers/settings_html/index.html.heex
@@ -145,9 +145,15 @@
                   <a href="/stripe/status" class="inline-flex items-center px-3 py-2 border border-gray-300 shadow-sm text-sm leading-4 font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                     View Details
                   </a>
-                  <button type="button" onclick="if(confirm('Are you sure you want to disconnect your Stripe account?')) { window.location.href = '/stripe/disconnect'; }" class="inline-flex items-center px-3 py-2 border border-red-300 shadow-sm text-sm leading-4 font-medium rounded-md text-red-700 bg-white hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">
-                    Disconnect
-                  </button>
+                  <.form for={%{}} action={~p"/stripe/disconnect"} method="post" class="inline">
+                    <.button 
+                      type="submit" 
+                      onclick="return confirm('Are you sure you want to disconnect your Stripe account?')"
+                      class="inline-flex items-center px-3 py-2 border border-red-300 shadow-sm text-sm leading-4 font-medium rounded-md text-red-700 bg-white hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                    >
+                      Disconnect
+                    </.button>
+                  </.form>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### TL;DR

Replaced the Stripe disconnect button with a proper form submission.

### What changed?

Converted the Stripe disconnect functionality from a JavaScript-based redirect to a proper form submission with a POST method. The previous implementation used an onclick handler that redirected the user after confirmation, while the new implementation uses Phoenix's form component with a submit button that triggers the confirmation dialog.

### How to test?

1. Navigate to the settings page
2. Locate the Stripe connection section
3. Click the "Disconnect" button
4. Confirm the dialog appears asking for confirmation
5. Verify that confirming properly disconnects the Stripe account via a POST request

### Why make this change?

This change improves security by using a proper POST request instead of a GET request for the disconnection action. Using POST for destructive actions follows web standards and prevents accidental disconnections that could happen with GET requests (e.g., from prefetching or search engine crawling). It also better aligns with Phoenix's component structure and form handling patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the Stripe account disconnect action by changing it from a link-based redirect to a form with a POST submission, enhancing security and semantic correctness.
  * The confirmation dialog remains, but now prevents form submission if canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->