### PR TITLE
excellent removals

### DIFF
--- a/lib/eventasaurus_app/ticketing.ex
+++ b/lib/eventasaurus_app/ticketing.ex
@@ -1271,7 +1271,18 @@ defmodule EventasaurusApp.Ticketing do
       checkout_params
     end
 
-    stripe_impl().create_checkout_session(checkout_params)
+    case stripe_impl().create_checkout_session(checkout_params) do
+      {:ok, session} ->
+        Logger.info("Successfully created Stripe checkout session", session_id: session["id"])
+        {:ok, session}
+
+      {:error, error} ->
+        Logger.error("Failed to create Stripe checkout session",
+          error: error,
+          checkout_params: Map.drop(checkout_params, [:idempotency_key])
+        )
+        {:error, error}
+    end
   end
 
   defp get_base_url do


### PR DESCRIPTION
### TL;DR

Simplified Stripe checkout session creation by temporarily disabling automatic tax calculation.

### What changed?

- Removed the `try_enable_automatic_tax` helper function that was attempting to conditionally enable automatic tax calculation
- Added comments indicating that automatic tax is temporarily disabled until Stripe account is properly configured
- Removed conditional logic that was adding tax behavior parameters when automatic tax was enabled
- Added improved error logging when Stripe checkout session creation fails, including the session ID on success and error details on failure

### How to test?

1. Create a checkout session for an event with tickets
2. Verify the checkout process completes successfully without tax calculation
3. Check logs to confirm the new logging messages appear correctly
4. Verify that the checkout session parameters no longer include automatic tax configuration

### Why make this change?

The automatic tax calculation was causing issues because the Stripe account isn't fully configured for tax calculation yet. This change simplifies the checkout process by temporarily disabling the automatic tax feature until the Stripe account is properly set up, preventing potential errors during checkout while maintaining a clean path to re-enable this feature in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic tax calculation from Stripe checkout sessions.

* **Chores**
  * Improved logging for Stripe checkout session creation, providing clearer success and error messages for better tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->