### PR TITLE
fix: Ensure consistent string return types in format_cents_as_dollars…

### DIFF
--- a/lib/eventasaurus_web/components/event_components.ex
+++ b/lib/eventasaurus_web/components/event_components.ex
@@ -1710,10 +1710,13 @@ defmodule EventasaurusWeb.EventComponents do
   # Helper function to format cents as dollars for display
   defp format_cents_as_dollars(nil), do: ""
   defp format_cents_as_dollars(""), do: ""
-  defp format_cents_as_dollars(cents) when is_integer(cents) and cents > 0, do: Float.round(cents / 100, 2)
+  defp format_cents_as_dollars(cents) when is_integer(cents) and cents > 0 do
+    Float.round(cents / 100, 2) |> Float.to_string()
+  end
   defp format_cents_as_dollars(cents) when is_binary(cents) do
     case Integer.parse(cents) do
-      {parsed, ""} when parsed > 0 -> Float.round(parsed / 100, 2)
+      {parsed, ""} when parsed > 0 ->
+        Float.round(parsed / 100, 2) |> Float.to_string()
       _ -> ""
     end
   end


### PR DESCRIPTION
… helper

- Updated format_cents_as_dollars/1 to always return strings
- Converts Float.round results to strings using Float.to_string()
- Prevents template rendering issues from mixed Float/String types
- Maintains empty string returns for invalid inputs

Addresses Code Rabbit review feedback on inconsistent return types.