### PR TITLE
small icons

### DIFF
--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -1072,7 +1072,9 @@ defmodule EventasaurusWeb.PublicEventLive do
                 <!-- When Section -->
                 <div class="flex items-start gap-3 mb-3">
                   <div class="flex-shrink-0 w-8 h-8 bg-blue-100 rounded-lg flex items-center justify-center">
-                    <.icon name="hero-calendar-days" class="w-4 h-4 text-blue-600" />
+                    <svg class="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                    </svg>
                   </div>
                   <div>
                     <h3 class="font-semibold text-gray-900 mb-1">When</h3>
@@ -1091,7 +1093,10 @@ defmodule EventasaurusWeb.PublicEventLive do
                 <!-- Where Section -->
                 <div class="flex items-start gap-3 mb-3">
                   <div class="flex-shrink-0 w-8 h-8 bg-green-100 rounded-lg flex items-center justify-center">
-                    <.icon name="hero-map-pin" class="w-4 h-4 text-green-600" />
+                    <svg class="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                    </svg>
                   </div>
                   <div>
                     <h3 class="font-semibold text-gray-900 mb-1">Where</h3>
@@ -1113,7 +1118,9 @@ defmodule EventasaurusWeb.PublicEventLive do
                 <!-- Event Type Section -->
                 <div class="flex items-start gap-3 mb-3">
                   <div class="flex-shrink-0 w-8 h-8 bg-purple-100 rounded-lg flex items-center justify-center">
-                    <.icon name="hero-ticket" class="w-4 h-4 text-purple-600" />
+                    <svg class="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z"></path>
+                    </svg>
                   </div>
                   <div>
                     <h3 class="font-semibold text-gray-900 mb-1">Event</h3>


### PR DESCRIPTION
### TL;DR

Replace Hero icons with inline SVG in the public event view

### What changed?

Replaced three Hero icon components with their equivalent inline SVG implementations:
- Calendar icon in the "When" section
- Map pin icon in the "Where" section
- Ticket icon in the "Event Type" section

### How to test?

1. Navigate to a public event page
2. Verify that the icons in the "When", "Where", and "Event Type" sections display correctly
3. Confirm that the styling (colors, sizes) of the icons matches the previous implementation

### Why make this change?

Using inline SVGs instead of the Hero icon component reduces dependencies and ensures consistent rendering across different environments. This approach also gives more direct control over the SVG attributes and can improve performance by eliminating the need to load external icon components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "When," "Where," and "Event Type" icons to use inline SVGs for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->