### PR TITLE
one more bug

### DIFF
--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -2093,7 +2093,12 @@ defmodule EventasaurusWeb.PublicEventLive do
         |> Enum.sort_by(& &1.id)
         |> Enum.map(fn poll ->
           # Filter out hidden poll options (status != "active") for public display
-          visible_options = Enum.filter(poll.poll_options || [], &(&1.status == "active"))
+          # Handle both loaded associations and NotLoaded structs
+          visible_options = case poll.poll_options do
+            %Ecto.Association.NotLoaded{} -> []
+            options when is_list(options) -> Enum.filter(options, &(&1.status == "active"))
+            _ -> []
+          end
           %{poll | poll_options: visible_options}
         end)
 


### PR DESCRIPTION
### TL;DR

Fix handling of unloaded poll options in public event display

### What changed?

Added proper handling for `Ecto.Association.NotLoaded` structs when filtering poll options in the `PublicEventLive` module. Previously, the code assumed poll options were always loaded, which could cause errors when the association wasn't preloaded. Now it properly handles three cases:
- When poll_options is a `NotLoaded` struct, returns an empty list
- When poll_options is a list, filters for active options as before
- For any other case, returns an empty list as a fallback

### How to test?

1. Navigate to a public event page that contains polls
2. Verify polls display correctly even when poll_options aren't preloaded
3. Test with both preloaded and non-preloaded poll options to ensure both cases work

### Why make this change?

This fixes a potential runtime error that could occur when accessing the public event page with polls that don't have their options preloaded. The previous implementation assumed poll_options would always be a list, but in cases where the association wasn't explicitly preloaded, it would be a `NotLoaded` struct instead, causing errors when attempting to filter it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of poll options to prevent errors when poll data is not fully loaded, ensuring polls display correctly even if some data is missing or not preloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->