### PR TITLE
buzzzz

### DIFF
--- a/lib/eventasaurus/events/poll_vote.ex
+++ b/lib/eventasaurus/events/poll_vote.ex
@@ -26,6 +26,7 @@ defmodule EventasaurusApp.Events.PollVote do
     |> put_voted_at()
     |> foreign_key_constraint(:poll_option_id)
     |> foreign_key_constraint(:voter_id)
+    |> foreign_key_constraint(:poll_id)
     |> unique_constraint([:poll_option_id, :voter_id],
          message: "You have already voted for this option")
   end
@@ -41,6 +42,7 @@ defmodule EventasaurusApp.Events.PollVote do
     |> put_voted_at()
     |> foreign_key_constraint(:poll_option_id)
     |> foreign_key_constraint(:voter_id)
+    |> foreign_key_constraint(:poll_id)
     |> unique_constraint([:poll_option_id, :voter_id],
          message: "You have already voted for this option")
   end
@@ -56,6 +58,7 @@ defmodule EventasaurusApp.Events.PollVote do
     |> put_voted_at()
     |> foreign_key_constraint(:poll_option_id)
     |> foreign_key_constraint(:voter_id)
+    |> foreign_key_constraint(:poll_id)
     |> unique_constraint([:poll_option_id, :voter_id],
          message: "You have already voted for this option")
   end
@@ -72,6 +75,7 @@ defmodule EventasaurusApp.Events.PollVote do
     |> put_voted_at()
     |> foreign_key_constraint(:poll_option_id)
     |> foreign_key_constraint(:voter_id)
+    |> foreign_key_constraint(:poll_id)
     |> unique_constraint([:poll_option_id, :voter_id],
          message: "You have already voted for this option")
   end
@@ -88,6 +92,7 @@ defmodule EventasaurusApp.Events.PollVote do
     |> put_voted_at()
     |> foreign_key_constraint(:poll_option_id)
     |> foreign_key_constraint(:voter_id)
+    |> foreign_key_constraint(:poll_id)
     |> unique_constraint([:poll_option_id, :voter_id],
          message: "You have already voted for this option")
   end


### PR DESCRIPTION
### TL;DR

Added poll_id foreign key constraint and improved error handling for missing polls in voting system.

### What changed?

- Added `foreign_key_constraint(:poll_id)` to all vote changeset functions in the `PollVote` module
- Enhanced the `create_vote_for_poll_option` function to handle cases where a poll option doesn't have an associated poll
- Added proper error handling that returns `{:error, "Poll not found for this option"}` when a poll is missing
- Restructured the vote creation logic to only proceed when a valid poll is found

### How to test?

1. Try to create a vote for a poll option that has a valid poll association - it should succeed
2. Try to create a vote for a poll option that doesn't have an associated poll - it should return the error message "Poll not found for this option"
3. Verify that the foreign key constraint for poll_id works by attempting to create a vote with an invalid poll_id

### Why make this change?

This change prevents potential data integrity issues by ensuring that votes are only created when they reference valid polls. The added foreign key constraint and nil-check provide an additional layer of validation to maintain data consistency in the voting system.