### PR TITLE
better google

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2789,40 +2789,37 @@ Hooks.PlacesSuggestionSearch = {
   
   // Add place metadata as hidden form inputs
   addPlaceMetadataToForm(form) {
-    // Remove any existing metadata inputs to avoid duplicates
-    const existingInputs = form.querySelectorAll('input[name*="metadata"]');
+    // Remove any existing place-related inputs to avoid duplicates
+    const existingInputs = form.querySelectorAll('input[name*="external_data"], input[name*="external_id"], input[name*="metadata"]');
     existingInputs.forEach(input => input.remove());
     
-    // Add place metadata as hidden inputs
-    const metadata = this.selectedPlaceData;
-    if (metadata) {
-      const metadataFields = [
-        'address', 'city', 'state', 'country', 'latitude', 'longitude',
-        'place_id', 'rating', 'price_level', 'phone', 'website'
-      ];
+    // Add place data using the consistent external API pattern (same as movies)
+    const placeData = this.selectedPlaceData;
+    if (placeData) {
+      // Create external_id following the "places:place_id" pattern
+      const externalIdInput = document.createElement('input');
+      externalIdInput.type = 'hidden';
+      externalIdInput.name = 'poll_option[external_id]';
+      externalIdInput.value = `places:${placeData.place_id}`;
+      form.appendChild(externalIdInput);
       
-      metadataFields.forEach(field => {
-        if (metadata[field] !== null && metadata[field] !== undefined) {
-          const input = document.createElement('input');
-          input.type = 'hidden';
-          input.name = `poll_option[metadata][${field}]`;
-          input.value = metadata[field];
-          form.appendChild(input);
-        }
-      });
+      // Create external_data with complete Google Places data
+      const externalDataInput = document.createElement('input');
+      externalDataInput.type = 'hidden';
+      externalDataInput.name = 'poll_option[external_data]';
+      externalDataInput.value = JSON.stringify(placeData);
+      form.appendChild(externalDataInput);
       
-      // Handle photos array separately
-      if (metadata.photos && metadata.photos.length > 0) {
-        metadata.photos.forEach((photo, index) => {
-          const input = document.createElement('input');
-          input.type = 'hidden';
-          input.name = `poll_option[metadata][photos][${index}]`;
-          input.value = photo;
-          form.appendChild(input);
-        });
+      // Create image_url if we have photos
+      if (placeData.photos && placeData.photos.length > 0) {
+        const imageUrlInput = document.createElement('input');
+        imageUrlInput.type = 'hidden';
+        imageUrlInput.name = 'poll_option[image_url]';
+        imageUrlInput.value = placeData.photos[0]; // First photo URL
+        form.appendChild(imageUrlInput);
       }
       
-      if (process.env.NODE_ENV !== 'production') console.log("Added place metadata to form submission");
+      if (process.env.NODE_ENV !== 'production') console.log("Added place data using external_id/external_data pattern");
     }
   }
 };

--- a/lib/eventasaurus_web/services/places_data_service.ex
+++ b/lib/eventasaurus_web/services/places_data_service.ex
@@ -1,0 +1,148 @@
+defmodule EventasaurusWeb.Services.PlacesDataService do
+  @moduledoc """
+  Shared service for preparing Google Places data consistently across all interfaces.
+  Ensures places data follows the same external_id/external_data pattern as movies.
+  """
+
+  @doc """
+  Prepares place option data in a consistent format following the external API pattern.
+  Uses external_id and external_data fields like movies, not metadata.
+  """
+  def prepare_place_option_data(place_data) do
+    # Extract the place_id (Google's unique identifier)
+    place_id = Map.get(place_data, "place_id") || Map.get(place_data, :place_id)
+
+    # Extract the first photo URL for image_url field
+    image_url = extract_place_image_url(place_data)
+
+    # Build rich description with rating, categories, and location
+    description = build_place_description(place_data)
+
+    # Get the place name
+    title = Map.get(place_data, "name") || Map.get(place_data, :name) || "Unknown Place"
+
+    # Prepare the data following the external API pattern
+    %{
+      "title" => title,
+      "description" => description,
+      "external_id" => "places:#{place_id}",  # Follow the "service:id" pattern
+      "external_data" => place_data,          # Store complete Google Places response
+      "image_url" => image_url                # Store first photo URL
+    }
+  end
+
+  # Extract image URL from Google Places data, handling both string and map formats
+  defp extract_place_image_url(place_data) do
+    photos = Map.get(place_data, "photos") || Map.get(place_data, :photos) || []
+
+    case photos do
+      [] -> nil
+      [first_photo | _] when is_binary(first_photo) ->
+        # Photos are already URL strings (from frontend processing)
+        first_photo
+      [first_photo | _] when is_map(first_photo) ->
+        # Photos are map objects with "url" key (from raw API)
+        Access.get(first_photo, "url") || Access.get(first_photo, :url)
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Build a rich description for the place including rating, categories, and location.
+  """
+  def build_place_description(place_data) do
+    parts = []
+
+    # Add rating if available
+    parts = if place_data["rating"] || place_data[:rating] do
+      rating = place_data["rating"] || place_data[:rating]
+      rating_text = "Rating: #{format_rating(rating)}★"
+      [rating_text | parts]
+    else
+      parts
+    end
+
+    # Add categories (place types)
+    parts = if get_place_categories(place_data) != [] do
+      categories_text = get_place_categories(place_data) |> Enum.join(", ")
+      [categories_text | parts]
+    else
+      parts
+    end
+
+    # Add location (address or vicinity)
+    parts = if get_place_location(place_data) do
+      location = get_place_location(place_data)
+      [location | parts]
+    else
+      parts
+    end
+
+    case parts do
+      [] -> ""
+      parts -> Enum.reverse(parts) |> Enum.join(" • ")
+    end
+  end
+
+  @doc """
+  Get place categories from types, filtering out generic ones.
+  """
+  def get_place_categories(place_data) do
+    types = place_data["types"] || place_data[:types] || []
+
+    types
+    |> Enum.reject(&(&1 in ["establishment", "point_of_interest"]))  # Filter generic types
+    |> Enum.map(&humanize_place_type/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.take(3)  # Limit to 3 categories for readability
+  end
+
+  @doc """
+  Get place location text from various location fields.
+  """
+  def get_place_location(place_data) do
+    place_data["vicinity"] || place_data[:vicinity] ||
+    place_data["formatted_address"] || place_data[:formatted_address] ||
+    place_data["address"] || place_data[:address]
+  end
+
+  # Private helper functions
+
+  defp format_rating(rating) when is_number(rating) do
+    Float.round(rating, 1)
+  end
+  defp format_rating(rating) when is_binary(rating) do
+    case Float.parse(rating) do
+      {float_val, _} -> Float.round(float_val, 1)
+      _ -> rating
+    end
+  end
+  defp format_rating(rating), do: rating
+
+  defp humanize_place_type(type) do
+    case type do
+      "restaurant" -> "Restaurant"
+      "food" -> "Food"
+      "meal_takeaway" -> "Takeaway"
+      "meal_delivery" -> "Delivery"
+      "cafe" -> "Cafe"
+      "bar" -> "Bar"
+      "night_club" -> "Nightclub"
+      "tourist_attraction" -> "Tourist attraction"
+      "amusement_park" -> "Amusement park"
+      "zoo" -> "Zoo"
+      "museum" -> "Museum"
+      "park" -> "Park"
+      "shopping_mall" -> "Shopping mall"
+      "store" -> "Store"
+      "lodging" -> "Lodging"
+      "gym" -> "Gym"
+      "spa" -> "Spa"
+      "movie_theater" -> "Movie theater"
+      "bowling_alley" -> "Bowling alley"
+      "casino" -> "Casino"
+      _ -> nil  # Filter out unrecognized types
+    end
+  end
+end

--- a/priv/repo/migrations/20250712120000_extend_image_url_field_for_places.exs
+++ b/priv/repo/migrations/20250712120000_extend_image_url_field_for_places.exs
@@ -1,0 +1,17 @@
+defmodule Eventasaurus.Repo.Migrations.ExtendImageUrlFieldForPlaces do
+  use Ecto.Migration
+
+  def up do
+    # Change image_url from varchar(255) to text to support longer Google Places photo URLs
+    alter table(:poll_options) do
+      modify :image_url, :text
+    end
+  end
+
+  def down do
+    # Revert back to varchar(255) - WARNING: This will truncate existing long URLs
+    alter table(:poll_options) do
+      modify :image_url, :string
+    end
+  end
+end

--- a/test/eventasaurus_web/services/places_data_service_test.exs
+++ b/test/eventasaurus_web/services/places_data_service_test.exs
@@ -1,0 +1,170 @@
+defmodule EventasaurusWeb.Services.PlacesDataServiceTest do
+  use ExUnit.Case, async: true
+  alias EventasaurusWeb.Services.PlacesDataService
+
+  describe "prepare_place_option_data/1" do
+    test "creates data in correct external_id/external_data pattern" do
+      place_data = %{
+        "place_id" => "ChIJGVtI4by3t4kRr51d_Qm_x58",
+        "name" => "Central Park",
+        "rating" => 4.6,
+        "user_ratings_total" => 123456,
+        "types" => ["park", "tourist_attraction", "establishment", "point_of_interest"],
+        "vicinity" => "New York, NY, USA",
+        "formatted_address" => "New York, NY, USA",
+        "photos" => [
+          %{"url" => "https://example.com/photo1.jpg"},
+          %{"url" => "https://example.com/photo2.jpg"}
+        ]
+      }
+
+      result = PlacesDataService.prepare_place_option_data(place_data)
+
+      # Verify it follows the external API pattern like movies
+      assert result["external_id"] == "places:ChIJGVtI4by3t4kRr51d_Qm_x58"
+      assert result["external_data"] == place_data
+      assert result["image_url"] == "https://example.com/photo1.jpg"
+      assert result["title"] == "Central Park"
+      assert String.contains?(result["description"], "Rating: 4.6★")
+      assert String.contains?(result["description"], "Park, Tourist attraction")
+      assert String.contains?(result["description"], "New York, NY, USA")
+    end
+
+    test "handles place data without photos" do
+      place_data = %{
+        "place_id" => "ChIJtest123",
+        "name" => "Test Restaurant",
+        "rating" => 4.2,
+        "types" => ["restaurant", "food"],
+        "vicinity" => "Test City"
+      }
+
+      result = PlacesDataService.prepare_place_option_data(place_data)
+
+      assert result["external_id"] == "places:ChIJtest123"
+      assert result["external_data"] == place_data
+      assert result["image_url"] == nil
+      assert result["title"] == "Test Restaurant"
+    end
+
+    test "handles minimal place data" do
+      place_data = %{
+        "place_id" => "ChIJminimal",
+        "name" => "Minimal Place"
+      }
+
+      result = PlacesDataService.prepare_place_option_data(place_data)
+
+      assert result["external_id"] == "places:ChIJminimal"
+      assert result["external_data"] == place_data
+      assert result["image_url"] == nil
+      assert result["title"] == "Minimal Place"
+      assert result["description"] == ""
+    end
+
+    test "handles photos as URL strings (from frontend processing)" do
+      place_data = %{
+        "place_id" => "ChIJGVtI4by3t4kRr51d_Qm_x58",
+        "name" => "Central Park",
+        "rating" => 4.6,
+        "types" => ["park", "tourist_attraction"],
+        "vicinity" => "New York, NY, USA",
+        "photos" => [
+          "https://maps.googleapis.com/maps/api/place/js/PhotoService.GetPhoto?token=12345",
+          "https://maps.googleapis.com/maps/api/place/js/PhotoService.GetPhoto?token=67890"
+        ]
+      }
+
+      result = PlacesDataService.prepare_place_option_data(place_data)
+
+      assert result["external_id"] == "places:ChIJGVtI4by3t4kRr51d_Qm_x58"
+      assert result["image_url"] == "https://maps.googleapis.com/maps/api/place/js/PhotoService.GetPhoto?token=12345"
+      assert Map.has_key?(result, "external_data")
+    end
+
+    test "handles photos as map objects (from raw API)" do
+      place_data = %{
+        "place_id" => "ChIJGVtI4by3t4kRr51d_Qm_x58",
+        "name" => "Central Park",
+        "rating" => 4.6,
+        "types" => ["park", "tourist_attraction"],
+        "vicinity" => "New York, NY, USA",
+        "photos" => [
+          %{"url" => "https://example.com/photo1.jpg"},
+          %{"url" => "https://example.com/photo2.jpg"}
+        ]
+      }
+
+      result = PlacesDataService.prepare_place_option_data(place_data)
+
+      assert result["external_id"] == "places:ChIJGVtI4by3t4kRr51d_Qm_x58"
+      assert result["image_url"] == "https://example.com/photo1.jpg"
+      assert Map.has_key?(result, "external_data")
+    end
+  end
+
+  describe "get_place_categories/1" do
+    test "filters and humanizes place types" do
+      place_data = %{
+        "types" => ["restaurant", "food", "establishment", "point_of_interest", "cafe"]
+      }
+
+      categories = PlacesDataService.get_place_categories(place_data)
+
+      assert "Restaurant" in categories
+      assert "Food" in categories
+      assert "Cafe" in categories
+      refute "establishment" in categories
+      refute "point_of_interest" in categories
+      assert length(categories) <= 3  # Limited to 3
+    end
+  end
+
+  describe "compatibility with poll_option schema" do
+    test "data structure is compatible with external_id patterns" do
+      place_data = %{
+        "place_id" => "ChIJGVtI4by3t4kRr51d_Qm_x58",
+        "name" => "Test Place"
+      }
+
+      result = PlacesDataService.prepare_place_option_data(place_data)
+
+      # Verify external_id follows the established pattern
+      assert String.starts_with?(result["external_id"], "places:")
+
+      # Verify the pattern can be parsed by existing PollOption functions
+      # (This tests compatibility with the external_service/1 function)
+      assert String.contains?(result["external_id"], ":")
+      [service, _id] = String.split(result["external_id"], ":", parts: 2)
+      assert service == "places"
+    end
+  end
+
+  describe "edge cases" do
+    test "handles missing place_id gracefully" do
+      place_data = %{
+        "name" => "Unknown Place",
+        "vicinity" => "Somewhere"
+      }
+
+      result = PlacesDataService.prepare_place_option_data(place_data)
+
+      assert result["external_id"] == "places:"
+      assert result["external_data"] == place_data
+      assert result["image_url"] == nil
+      assert result["description"] == "Somewhere"  # Vicinity is included in description
+    end
+
+    test "handles empty photos array" do
+      place_data = %{
+        "place_id" => "ChIJGVtI4by3t4kRr51d_Qm_x58",
+        "name" => "Test Place",
+        "photos" => []
+      }
+
+      result = PlacesDataService.prepare_place_option_data(place_data)
+
+      assert result["image_url"] == nil
+    end
+  end
+end


### PR DESCRIPTION
### TL;DR

Refactored Google Places integration to use the consistent external_id/external_data pattern instead of metadata fields.

### What changed?

- Created a new `PlacesDataService` module to standardize place data handling
- Updated the frontend JS to store place data using `external_id` and `external_data` fields instead of metadata
- Modified `OptionSuggestionComponent` to process place data similar to movie data
- Added a migration to extend the `image_url` field to text type to support longer Google Places photo URLs
- Added comprehensive tests for the new PlacesDataService

### How to test?

1. Create a new poll with the "Places" type
2. Search for and select a place from Google Places suggestions
3. Verify the place appears with proper formatting, including:
   - Correct title and description with rating, categories, and location
   - Place photo displayed correctly
   - Proper external_id format ("places:PLACE_ID")

### Why make this change?

This change aligns the Places integration with the existing Movies integration by using the same external_id/external_data pattern. This creates a more consistent data structure across different poll types, simplifies the codebase, and makes it easier to add new external data sources in the future. The extended image_url field also prevents truncation of Google Places photo URLs.