### PR TITLE
fix bugs

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2770,10 +2770,24 @@ Hooks.PlacesSuggestionSearch = {
   closePlacesDropdown(keepText = false) {
     if (this.inputEl) {
       if (!keepText) {
+        // Temporarily disable autocomplete before clearing to prevent retriggering
+        if (this.autocomplete) {
+          this.autocomplete.setOptions({ types: [] });
+        }
+        
         // Clear the input field to close the dropdown
         this.inputEl.value = '';
-        // Only trigger input event when clearing text to ensure proper cleanup
-        this.inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+        // Use change event to avoid retriggering autocomplete
+        this.inputEl.dispatchEvent(new Event('change', { bubbles: true }));
+        
+        // Re-enable autocomplete after a short delay
+        if (this.autocomplete) {
+          setTimeout(() => {
+            if (this.autocomplete && this.mounted) {
+              this.autocomplete.setOptions({ types: ['establishment'] });
+            }
+          }, 100);
+        }
       }
       this.inputEl.blur();
     }

--- a/lib/eventasaurus_web/live/components/public_generic_poll_component.ex
+++ b/lib/eventasaurus_web/live/components/public_generic_poll_component.ex
@@ -279,7 +279,7 @@ defmodule EventasaurusWeb.PublicGenericPollComponent do
                      data-event-venue-lat={@event && @event.venue && @event.venue.latitude}
                      data-event-venue-lng={@event && @event.venue && @event.venue.longitude}
                      data-event-venue-name={@event && @event.venue && @event.venue.name}
-                     data-poll-options-data={Jason.encode!(extract_poll_options_coordinates(@poll.poll_options))}>
+                     data-poll-options-data={Jason.encode!(extract_poll_options_coordinates(@poll_options))}>
                   <div class="mb-4">
                     <h4 class="text-md font-medium text-gray-900 mb-2">Add <%= get_suggestion_title(@poll.poll_type) %></h4>
                     <p class="text-sm text-gray-600">Share your suggestion with the group</p>


### PR DESCRIPTION
### TL;DR

Fixed Google Places autocomplete dropdown issues and corrected poll options data reference in the map component.

### What changed?

- Modified the `closePlacesDropdown` method in the Places suggestion hook to:
  - Temporarily disable autocomplete before clearing the input field
  - Use a `change` event instead of `input` event to avoid retriggering the autocomplete
  - Re-enable autocomplete after a short delay
  - Add proper checks for autocomplete existence and component mount status

- Fixed a data reference in the public generic poll component:
  - Changed `@poll.poll_options` to `@poll_options` in the data attribute for poll options coordinates

### How to test?

1. Open a page with the Places suggestion search
2. Enter a location and select it
3. Clear the input field and verify the dropdown doesn't reappear unexpectedly
4. View a public poll with location options and verify the map displays correctly with all poll options

### Why make this change?

The Google Places autocomplete dropdown was reappearing unexpectedly when clearing the input field due to the input event retriggering the autocomplete. This change implements a more robust approach to properly close the dropdown while preventing unwanted side effects.

Additionally, the poll options data reference was incorrect in the map component, causing potential issues with displaying location options on the map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the behavior of the Google Places autocomplete dropdown to prevent unwanted retriggering of suggestions when clearing the input field.
  * Adjusted poll option data handling to ensure the front-end receives the correct preloaded poll options for rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->