### PR TITLE
a few more

### DIFF
--- a/lib/eventasaurus/events/poll.ex
+++ b/lib/eventasaurus/events/poll.ex
@@ -1,8 +1,10 @@
 defmodule EventasaurusApp.Events.Poll do
   use Ecto.Schema
   import Ecto.Changeset
-  alias EventasaurusApp.Events.{Event, PollOption}
+  import Ecto.Query, only: [from: 2]
+  alias EventasaurusApp.Events.{Event, PollOption, PollVote}
   alias EventasaurusApp.Accounts.User
+  alias EventasaurusApp.Repo
 
   schema "polls" do
     field :title, :string
@@ -23,6 +25,13 @@ defmodule EventasaurusApp.Events.Poll do
     has_many :poll_options, PollOption
 
     timestamps()
+  end
+
+  @doc """
+  Callback to populate virtual fields after loading from database.
+  """
+  def __after_load__(poll) do
+    %{poll | status: status(poll)}
   end
 
   @doc """
@@ -378,12 +387,6 @@ defmodule EventasaurusApp.Events.Poll do
 
   defp validate_no_votes_for_building_transition(changeset) do
     poll = changeset.data
-
-    # Check if poll has any votes by loading them
-    # We'll need to import Ecto.Query and alias the PollVote module
-    import Ecto.Query
-    alias EventasaurusApp.Events.PollVote
-    alias EventasaurusApp.Repo
 
     vote_count = from(v in PollVote,
                      join: o in assoc(v, :poll_option),

--- a/lib/eventasaurus_app/events.ex
+++ b/lib/eventasaurus_app/events.ex
@@ -4202,15 +4202,20 @@ defmodule EventasaurusApp.Events do
   @doc """
   Disables suggestions during voting by transitioning from voting_with_suggestions to voting_only.
   """
-  def disable_poll_suggestions(%Poll{} = poll) do
-    if poll.phase in ["voting_with_suggestions", "voting"] do
-      poll
-      |> Poll.phase_transition_changeset("voting_only")
-      |> Repo.update()
-    else
-      {:error, "Poll is not in a phase that allows disabling suggestions"}
-    end
+  def disable_poll_suggestions(%Poll{phase: "voting_with_suggestions"} = poll) do
+    poll
+    |> Poll.phase_transition_changeset("voting_only")
+    |> Repo.update()
   end
+
+  def disable_poll_suggestions(%Poll{phase: "voting"} = poll) do  # Legacy support
+    poll
+    |> Poll.phase_transition_changeset("voting_only")
+    |> Repo.update()
+  end
+
+  def disable_poll_suggestions(%Poll{}), do:
+    {:error, "Poll is not in a phase that allows disabling suggestions"}
 
   @doc """
   Finalizes a poll (single-argument version for LiveView component).


### PR DESCRIPTION
### TL;DR

Improved poll phase transitions and added callback for virtual field population.

### What changed?

- Added `__after_load__/1` callback to populate virtual fields (specifically the `status` field) after loading a poll from the database
- Refactored `disable_poll_suggestions/1` function to use pattern matching for different poll phases instead of conditional logic
- Moved module imports and aliases to the top of the Poll module for better organization
- Fixed query in `validate_no_votes_for_building_transition/1` by removing redundant imports

### How to test?

1. Create a poll and verify that its status is correctly populated after loading
2. Test disabling suggestions on polls in different phases:
   - Should work for polls in "voting_with_suggestions" phase
   - Should work for polls in "voting" phase (legacy support)
   - Should return an error for polls in other phases

### Why make this change?

This refactoring improves code organization and maintainability by:
1. Ensuring virtual fields are properly populated when polls are loaded
2. Using Elixir's pattern matching for cleaner function definitions
3. Following best practices for module imports and aliases placement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Polls now display a legacy status value based on their current phase for improved clarity.

* **Refactor**
  * The process for disabling poll suggestions has been streamlined for more explicit handling of poll phases, with clearer error messaging when the action is not allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->