### PR TITLE
final fixes polling

### DIFF
--- a/lib/eventasaurus_web/services/stripe_currency_service.ex
+++ b/lib/eventasaurus_web/services/stripe_currency_service.ex
@@ -109,7 +109,7 @@ defmodule EventasaurusWeb.Services.StripeCurrencyService do
               # Return what we have so far to avoid infinite recursion
               {:ok, %{data: all_specs}}
             _ ->
-              last_id = List.last(specs).id
+              last_id = (List.last(specs)).id
               fetch_all_country_specs(all_specs, last_id)
           end
         else


### PR DESCRIPTION
### TL;DR

Fixed a syntax issue in the `fetch_all_country_specs` function by adding parentheses around `List.last(specs)` before accessing the `id` property.

### What changed?

Added parentheses around `List.last(specs)` when accessing the `id` property in the `fetch_all_country_specs` function. This ensures proper operator precedence when accessing the `id` field from the result of `List.last(specs)`.

Changed:
```elixir
last_id = List.last(specs).id
```

To:
```elixir
last_id = (List.last(specs)).id
```

### How to test?

1. Run the test suite to ensure the Stripe currency service functions correctly
2. Test the pagination functionality of country specs by making API calls that would trigger the recursive `fetch_all_country_specs` function
3. Verify that country specs are properly retrieved with the correct pagination handling

### Why make this change?

This change fixes a potential syntax issue in Elixir where the dot operator precedence might cause unexpected behavior. By adding parentheses, we ensure that `List.last(specs)` is evaluated first before accessing the `id` property, making the code more robust and preventing potential runtime errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code clarity with minor syntax adjustments. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->