### PR TITLE
fix mistakes

### DIFF
--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -1595,7 +1595,7 @@ defmodule EventasaurusWeb.PublicEventLive do
 
           <!-- Event Polls Section -->
           <%= if length(@event_polls || []) > 0 do %>
-            <div class="space-y-6">
+            <div class="space-y-6 mt-12">
               <%= for poll <- @event_polls do %>
                 <div class="bg-white border border-gray-200 rounded-xl p-6 mb-8 shadow-sm">
                   <div class="flex items-center gap-3 mb-4">


### PR DESCRIPTION
### TL;DR

Removed date selection calendar functionality from the poll creation component.

### What changed?

- Removed the date selection interface and calendar component from the poll creation form
- Removed all related state assignments (`showing_calendar`, `selected_dates`)
- Removed event handlers for calendar functionality (`toggle_calendar`, `calendar_date_selected`, `remove_date`, `add_quick_date`)
- Removed helper functions for date formatting and display
- Removed code that created date options for polls
- Added margin (`mt-12`) to the event polls section in the public event view

### How to test?

1. Navigate to the poll creation interface
2. Verify that the date selection calendar no longer appears when creating a poll
3. Check that the event polls section in the public event view has proper spacing

### Why make this change?

This change simplifies the poll creation component by removing the date selection calendar functionality, which may be replaced with a different approach or moved to a separate component. The added margin in the public event view improves the visual spacing between sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * None.

* **Bug Fixes**
  * None.

* **Style**
  * Improved vertical spacing above the polls list for a cleaner layout.

* **Refactor**
  * Removed all date selection and calendar-based features from poll creation. Date selection polls are no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->