### PR TITLE
final changes before merge

### DIFF
--- a/lib/eventasaurus_web/adapters/date_poll_adapter.ex
+++ b/lib/eventasaurus_web/adapters/date_poll_adapter.ex
@@ -51,13 +51,6 @@ defmodule EventasaurusWeb.Adapters.DatePollAdapter do
   defp get_day_name(7), do: "Sunday"
 
   @doc """
-  Helper function to get all data for a date_selection poll in legacy format.
-
-  This is the main function UI components should use to get a complete legacy-format
-  data structure from a generic date_selection poll.
-  """
-
-  @doc """
   Get a generic poll with all related data preloaded.
   """
   def get_generic_poll_with_options_and_votes(poll_id) do
@@ -87,10 +80,6 @@ defmodule EventasaurusWeb.Adapters.DatePollAdapter do
   def get_poll_with_data(poll_id) do
     get_generic_poll_with_options_and_votes(poll_id)
   end
-
-  @doc """
-  Get a poll using the Events context functions.
-  """
 
   @doc """
   Extracts all votes from a poll's options.
@@ -177,15 +166,6 @@ defmodule EventasaurusWeb.Adapters.DatePollAdapter do
   end
 
   def validate_date_option(_), do: {:error, "Invalid option structure"}
-
-  @doc """
-  Batch convert multiple polls from generic to legacy format.
-  """
-
-  @doc """
-  Performance-optimized version for large datasets.
-  Processes polls in batches to avoid memory issues.
-  """
 
   # Phoenix.HTML Safety Functions
 

--- a/priv/repo/migrations/20250717153302_drop_legacy_event_date_polling_tables_final.exs
+++ b/priv/repo/migrations/20250717153302_drop_legacy_event_date_polling_tables_final.exs
@@ -1,0 +1,65 @@
+defmodule EventasaurusApp.Repo.Migrations.DropLegacyEventDatePollingTablesFinal do
+  use Ecto.Migration
+
+  def up do
+    # Drop tables in reverse dependency order to avoid foreign key constraint issues
+    
+    # 1. Drop event_date_votes table first (depends on event_date_options)
+    # Remove the constraint first if it exists
+    execute "ALTER TABLE event_date_votes DROP CONSTRAINT IF EXISTS valid_vote_type"
+    drop_if_exists table(:event_date_votes)
+
+    # 2. Drop event_date_options table (depends on event_date_polls)
+    drop_if_exists table(:event_date_options)
+
+    # 3. Drop event_date_polls table (depends on events and users, but those remain)
+    drop_if_exists table(:event_date_polls)
+  end
+
+  def down do
+    # Recreate tables in dependency order for rollback
+    
+    # 1. Recreate event_date_polls table first
+    create table(:event_date_polls) do
+      add :event_id, references(:events, on_delete: :delete_all), null: false
+      add :created_by_id, references(:users, on_delete: :nilify_all), null: false
+      add :voting_deadline, :utc_datetime
+      add :finalized_date, :date
+
+      timestamps()
+    end
+
+    create index(:event_date_polls, [:created_by_id])
+    create unique_index(:event_date_polls, [:event_id])
+    create index(:event_date_polls, [:voting_deadline])
+
+    # 2. Recreate event_date_options table
+    create table(:event_date_options) do
+      add :event_date_poll_id, references(:event_date_polls, on_delete: :delete_all), null: false
+      add :date, :date, null: false
+
+      timestamps()
+    end
+
+    create index(:event_date_options, [:event_date_poll_id])
+    create unique_index(:event_date_options, [:event_date_poll_id, :date])
+    create index(:event_date_options, [:date])
+
+    # 3. Recreate event_date_votes table
+    create table(:event_date_votes) do
+      add :event_date_option_id, references(:event_date_options, on_delete: :delete_all), null: false
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :vote_type, :string, null: false
+
+      timestamps()
+    end
+
+    create index(:event_date_votes, [:event_date_option_id])
+    create index(:event_date_votes, [:user_id])
+    create unique_index(:event_date_votes, [:event_date_option_id, :user_id])
+    create index(:event_date_votes, [:vote_type])
+
+    # Recreate the constraint
+    execute "ALTER TABLE event_date_votes ADD CONSTRAINT valid_vote_type CHECK (vote_type IN ('yes', 'if_need_be', 'no'))"
+  end
+end


### PR DESCRIPTION
### TL;DR

Removed unused documentation and added migration to drop legacy date polling tables.

### What changed?

- Removed unused documentation comments from `DatePollAdapter` module
- Added a new migration file `drop_legacy_event_date_polling_tables_final.exs` that:
  - Drops the legacy tables: `event_date_votes`, `event_date_options`, and `event_date_polls`
  - Includes a rollback function to recreate these tables if needed

### How to test?

1. Run the migration with `mix ecto.migrate`
2. Verify that the legacy tables are no longer present in the database
3. Test that all date polling functionality still works correctly using the new implementation
4. Optionally, test the rollback with `mix ecto.rollback` to ensure tables can be recreated if needed

### Why make this change?

We've completed the migration to the new generic polling system and no longer need the legacy date polling tables. This change completes the cleanup process by removing unused documentation and dropping tables that are no longer in use, reducing database overhead and simplifying our schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal documentation for legacy poll data handling.
  * Dropped unused legacy event date polling tables from the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->