### PR TITLE
better width

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1455,11 +1455,31 @@ body[class*="theme-"] .theme-card:hover {
 
 /* Mobile layout improvements */
 @media (max-width: 639px) {
-  /* Content area with minimal padding on mobile - scoped to event pages */
-  .public-event-page .container,
-  .event-page-grid .container {
-    padding-left: 0.1875rem !important; /* 3px padding on mobile - 50% wider content */
-    padding-right: 0.1875rem !important; /* 3px padding on mobile - 50% wider content */
+  /* Balanced padding for mobile event pages - ~81% viewport usage */
+  /* Target the radiant component wrapper specifically */
+  .min-h-screen .px-6:has(.event-page-grid) {
+    padding-left: max(1rem, env(safe-area-inset-left)) !important;
+    padding-right: max(1rem, env(safe-area-inset-right)) !important;
+  }
+  
+  /* Also target with higher specificity using multiple classes */
+  .px-6[class*="lg:px-8"]:has(.event-page-grid) {
+    padding-left: max(1rem, env(safe-area-inset-left)) !important;
+    padding-right: max(1rem, env(safe-area-inset-right)) !important;
+  }
+  
+  /* Target the p-6 wrapper inside container */
+  .p-6:has(.event-page-grid) {
+    padding: 0.5rem !important;
+  }
+  
+  /* Content area with balanced padding on mobile - scoped to event pages */
+  /* Target containers that have event-page-grid as a child */
+  .container:has(.event-page-grid),
+  .public-event-page .container {
+    /* 8px padding for better balance */
+    padding-left: max(0.5rem, env(safe-area-inset-left)) !important;
+    padding-right: max(0.5rem, env(safe-area-inset-right)) !important;
   }
   
   /* Stack voting section header on mobile - more specific selector */


### PR DESCRIPTION
### TL;DR

Improved mobile layout for event pages with better padding and safe area insets.

### What changed?

- Replaced the minimal 3px padding with a more balanced approach using 8px (0.5rem) padding
- Added support for iOS safe area insets using `env(safe-area-inset-left/right)`
- Used the `:has()` selector to target specific containers within event pages
- Applied different padding rules to various container elements to create a consistent mobile experience
- Optimized for approximately 81% viewport usage on mobile devices

### How to test?

1. Open an event page on a mobile device or using responsive design mode in browser dev tools
2. Set viewport width to less than 640px
3. Verify that content has appropriate padding (not too tight against edges)
4. Test on iOS devices to ensure safe area insets are respected
5. Compare with previous layout to confirm improved readability and spacing

### Why make this change?

The previous 3px padding was too minimal, causing content to appear cramped on mobile devices. This change provides a more balanced layout with appropriate spacing that respects device safe areas while still maximizing available screen space. The improved padding creates a better reading experience without sacrificing too much content width.