### PR TITLE
last fixes

### DIFF
--- a/lib/eventasaurus_app/events.ex
+++ b/lib/eventasaurus_app/events.ex
@@ -3906,7 +3906,11 @@ defmodule EventasaurusApp.Events do
       if voting_system in ["binary", "star"] do
         case get_user_poll_vote(poll_option, user) do
           nil -> :ok
-          existing_vote -> Repo.delete!(existing_vote)
+          existing_vote -> 
+            case delete_poll_vote(existing_vote) do
+              {:ok, _} -> :ok
+              {:error, reason} -> Repo.rollback(reason)
+            end
         end
       end
 


### PR DESCRIPTION
### TL;DR

Improved poll vote handling and broadcast throttling mechanism to prevent data loss and manage system resources better.

### What changed?

- Enhanced error handling in `events.ex` when deleting poll votes by properly handling errors and rolling back transactions
- Refactored the broadcast throttler to limit the total number of pending broadcasts across all polls instead of per poll
- Added a mechanism to drop the oldest pending broadcast when the maximum limit is reached
- Implemented a new `drop_oldest_pending_broadcast/1` function to identify and remove the oldest broadcast based on timestamp

### How to test?

1. Test poll voting by creating a poll with binary or star voting system
2. Vote on an option and then change your vote multiple times in quick succession
3. Verify that no errors occur and transactions are properly handled
4. Create multiple polls and generate rapid vote updates to trigger the broadcast throttling
5. Verify that the system properly manages broadcasts when the limit is reached by checking logs for "dropping oldest" messages

### Why make this change?

The previous implementation had two issues:
1. Poll vote deletion didn't properly handle errors, potentially leaving the system in an inconsistent state
2. The broadcast throttler limited pending broadcasts per poll but didn't have a global limit, which could lead to resource exhaustion under heavy load

These changes improve system stability and resource management while ensuring data consistency during high-traffic scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when deleting existing poll votes, ensuring failed deletions are properly managed and transactions are rolled back when necessary.

* **Refactor**
  * Updated broadcast throttling to enforce a global limit on pending broadcasts, replacing the previous per-poll limit for more consistent system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->