### PR TITLE
final fix

### DIFF
--- a/lib/eventasaurus_web/services/broadcast_throttler.ex
+++ b/lib/eventasaurus_web/services/broadcast_throttler.ex
@@ -180,8 +180,9 @@ defmodule EventasaurusWeb.Services.BroadcastThrottler do
     oldest_poll_id = state.pending_broadcasts
     |> Map.keys()
     |> Enum.min_by(fn poll_id -> 
-      # Use the actual queue time, defaulting to current time if not found
-      Map.get(state.queue_times, poll_id, System.monotonic_time(:millisecond))
+      # Use the actual queue time, defaulting to 0 (very old) if not found
+      # This ensures broadcasts without queue times are dropped first
+      Map.get(state.queue_times, poll_id, 0)
     end, fn -> nil end)
     
     if oldest_poll_id do


### PR DESCRIPTION
### TL;DR

Changed the default queue time value for broadcasts without queue times to prioritize their removal.

### What changed?

Modified the `BroadcastThrottler` to use `0` instead of `System.monotonic_time(:millisecond)` as the default value when a poll's queue time is not found. This ensures that broadcasts without queue times are treated as very old and dropped first when throttling is needed.

### How to test?

1. Create a scenario where the broadcast throttler needs to drop messages
2. Verify that broadcasts without queue times are dropped before those with queue times
3. Monitor the system under load to ensure throttling behavior works as expected

### Why make this change?

The previous implementation used the current time as a default, which could cause newer broadcasts without queue times to be prioritized over older broadcasts with queue times. This change ensures a more logical throttling behavior where broadcasts without queue times (which might be in an inconsistent state) are dropped first, improving the reliability of the throttling mechanism.