### PR TITLE
fixes for naming

### DIFF
--- a/lib/eventasaurus_web/live/components/public_generic_poll_component.ex
+++ b/lib/eventasaurus_web/live/components/public_generic_poll_component.ex
@@ -13,7 +13,6 @@ defmodule EventasaurusWeb.PublicGenericPollComponent do
   alias EventasaurusApp.Repo
   alias EventasaurusWeb.Utils.TimeUtils
   alias EventasaurusWeb.Utils.PollPhaseUtils
-  alias EventasaurusWeb.Utils.PollNameUtils
 
   import EventasaurusWeb.PollView, only: [poll_emoji: 1]
   import EventasaurusWeb.VoterCountDisplay
@@ -507,7 +506,7 @@ defmodule EventasaurusWeb.PublicGenericPollComponent do
     case poll_type do
       "places" -> "Enter place name..."
       "time" -> "Select a time..."
-      "date_selection" -> "Select a date..."
+      "date_selection" -> "Select a DateTime..."
       "custom" -> "Enter your option..."
       _ -> "Enter title..."
     end


### PR DESCRIPTION
### TL;DR

Updated placeholder text for date selection polls.

### What changed?

Changed the placeholder text for date selection polls from "Select a date..." to "Select a DateTime..." in the `public_generic_poll_component.ex` file. Also removed an unused alias to `PollNameUtils`.

### How to test?

1. Navigate to a date selection poll
2. Verify that the placeholder text now shows "Select a DateTime..." instead of "Select a date..."

### Why make this change?

The updated placeholder text more accurately reflects that users are selecting both a date and time in date selection polls, providing clearer guidance to users interacting with this poll type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the placeholder text for the "date_selection" poll type to "Select a DateTime...".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->