### PR TITLE
last changes

### DIFF
--- a/lib/eventasaurus_app/events.ex
+++ b/lib/eventasaurus_app/events.ex
@@ -2827,10 +2827,14 @@ defmodule EventasaurusApp.Events do
           where: po.poll_id == ^poll.id,
           order_by: [asc: fragment("
             CASE 
-              WHEN ?->'date' IS NOT NULL THEN (?->>'date')::date
+              WHEN ?->'date' IS NOT NULL THEN 
+                CASE 
+                  WHEN ?->>'date' ~ '^\\d{4}-\\d{2}-\\d{2}$' THEN (?->>'date')::date
+                  ELSE '9999-12-31'::date
+                END
               ELSE '9999-12-31'::date
             END
-          ", po.metadata, po.metadata)],
+          ", po.metadata, po.metadata, po.metadata)],
           preload: [:suggested_by, :votes]
       else
         from po in PollOption,
@@ -2856,10 +2860,14 @@ defmodule EventasaurusApp.Events do
         where: po.poll_id == ^poll.id,
         order_by: [asc: fragment("
           CASE 
-            WHEN ?->'date' IS NOT NULL THEN (?->>'date')::date
+            WHEN ?->'date' IS NOT NULL THEN 
+              CASE 
+                WHEN ?->>'date' ~ '^\\d{4}-\\d{2}-\\d{2}$' THEN (?->>'date')::date
+                ELSE '9999-12-31'::date
+              END
             ELSE '9999-12-31'::date
           END
-        ", po.metadata, po.metadata)],
+        ", po.metadata, po.metadata, po.metadata)],
         preload: [:suggested_by, :votes]
     else
       # For other poll types, use the regular order_index

--- a/lib/eventasaurus_web/live/components/option_suggestion_component.ex
+++ b/lib/eventasaurus_web/live/components/option_suggestion_component.ex
@@ -2031,8 +2031,10 @@ defmodule EventasaurusWeb.OptionSuggestionComponent do
         end)
       
       _ ->
-        # For other poll types, keep the existing order (by order_index)
-        options
+        # For other poll types, sort by order_index
+        Enum.sort_by(options, fn option ->
+          option.order_index || 0
+        end)
     end
   end
 


### PR DESCRIPTION
### TL;DR

Fixed date sorting in polls and improved option ordering for non-date poll types.

### What changed?

- Enhanced the SQL query for date-based polls to properly handle invalid date formats
  - Added a regex check (`^\\d{4}-\\d{2}-\\d{2}$`) to validate date format
  - Invalid dates now default to '9999-12-31' (end of sorting order)
- Updated the `OptionSuggestionComponent` to explicitly sort non-date poll options by `order_index`
  - Previously non-date polls relied on existing order
  - Now they're properly sorted by `order_index` with a fallback to 0

### How to test?

1. Create a date-based poll with some valid dates and some invalid date formats
2. Verify that valid dates are sorted correctly and invalid dates appear at the end
3. Create a non-date poll type and add options in random order
4. Verify that options are displayed in the correct order based on their `order_index`

### Why make this change?

The previous implementation had two issues:
1. It would crash when encountering invalid date formats in date-based polls
2. Non-date poll types weren't consistently sorted by `order_index`

These changes improve stability by handling invalid date formats gracefully and ensure consistent ordering across all poll types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting of poll options for date selection polls to ensure invalid or incorrectly formatted dates are always shown last.
  * Ensured poll options for non-date/time polls are now consistently ordered by their assigned order, providing a more predictable display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->