### PR TITLE
first step delete poll

### DIFF
--- a/lib/eventasaurus_app/events.ex
+++ b/lib/eventasaurus_app/events.ex
@@ -3105,6 +3105,20 @@ defmodule EventasaurusApp.Events do
     Repo.delete(poll_option)
   end
 
+  @doc """
+  Checks if a user can delete their own poll suggestion within the 5-minute window.
+  
+  Returns true if:
+  - The user is the one who suggested the option
+  - The option was created less than 5 minutes ago
+  """
+  def can_delete_own_suggestion?(%PollOption{} = poll_option, %User{} = user) do
+    poll_option.suggested_by_id == user.id &&
+    NaiveDateTime.diff(NaiveDateTime.utc_now(), poll_option.inserted_at, :second) <= 300
+  end
+
+  def can_delete_own_suggestion?(_, _), do: false
+
   # =================
   # Date Selection Poll Options
   # =================

--- a/test/eventasaurus_app/events/poll_option_deletion_test.exs
+++ b/test/eventasaurus_app/events/poll_option_deletion_test.exs
@@ -1,0 +1,179 @@
+defmodule EventasaurusApp.Events.PollOptionDeletionTest do
+  use EventasaurusApp.DataCase, async: true
+
+  import EventasaurusApp.EventsFixtures
+  import EventasaurusApp.AccountsFixtures
+  import Ecto.Query
+
+  alias EventasaurusApp.Events
+  alias EventasaurusApp.Events.PollOption
+
+  setup do
+    user = user_fixture()
+    other_user = user_fixture()
+    event = event_fixture()
+    
+    poll = poll_fixture(%{
+      event_id: event.id,
+      created_by_id: user.id,
+      title: "Test Poll",
+      poll_type: "general",
+      voting_system: "binary",
+      phase: "list_building"
+    })
+
+    %{user: user, other_user: other_user, event: event, poll: poll}
+  end
+
+  describe "can_delete_own_suggestion?/2" do
+    test "returns true when user is the suggester and within 5 minutes", %{poll: poll, user: user} do
+      # Create a poll option suggested by the user
+      {:ok, option} = Events.create_poll_option(%{
+        poll_id: poll.id,
+        suggested_by_id: user.id,
+        title: "Test Option",
+        status: "active"
+      })
+
+      # Should be able to delete immediately after creation
+      assert Events.can_delete_own_suggestion?(option, user) == true
+    end
+
+    test "returns false when user is not the suggester", %{poll: poll, user: user, other_user: other_user} do
+      # Create a poll option suggested by other_user
+      {:ok, option} = Events.create_poll_option(%{
+        poll_id: poll.id,
+        suggested_by_id: other_user.id,
+        title: "Test Option",
+        status: "active"
+      })
+
+      # User should not be able to delete other user's suggestion
+      assert Events.can_delete_own_suggestion?(option, user) == false
+    end
+
+    test "returns false when more than 5 minutes have passed", %{poll: poll, user: user} do
+      # Create a poll option with an old timestamp
+      {:ok, option} = Events.create_poll_option(%{
+        poll_id: poll.id,
+        suggested_by_id: user.id,
+        title: "Test Option",
+        status: "active"
+      })
+
+      # Manually update the inserted_at to be 6 minutes ago
+      six_minutes_ago = NaiveDateTime.utc_now()
+      |> NaiveDateTime.add(-360, :second)
+      |> NaiveDateTime.truncate(:second)
+      
+      Ecto.Changeset.change(option, %{inserted_at: six_minutes_ago})
+      |> EventasaurusApp.Repo.update!()
+
+      # Reload the option to get the updated timestamp
+      option = EventasaurusApp.Repo.get!(PollOption, option.id)
+
+      # Should not be able to delete after 5 minutes
+      assert Events.can_delete_own_suggestion?(option, user) == false
+    end
+
+    test "returns false for nil inputs", %{user: user} do
+      assert Events.can_delete_own_suggestion?(nil, user) == false
+      assert Events.can_delete_own_suggestion?(%PollOption{}, nil) == false
+      assert Events.can_delete_own_suggestion?(nil, nil) == false
+    end
+  end
+
+  describe "delete_poll_option/1" do
+    test "successfully deletes a poll option", %{poll: poll, user: user} do
+      # Create a poll option
+      {:ok, option} = Events.create_poll_option(%{
+        poll_id: poll.id,
+        suggested_by_id: user.id,
+        title: "Test Option",
+        status: "active"
+      })
+
+      # Delete the option
+      assert {:ok, _deleted_option} = Events.delete_poll_option(option)
+
+      # Verify it's deleted
+      assert EventasaurusApp.Repo.get(PollOption, option.id) == nil
+    end
+
+    test "cascade deletes associated votes", %{poll: poll, user: user, other_user: other_user} do
+      # Create a poll option
+      {:ok, option} = Events.create_poll_option(%{
+        poll_id: poll.id,
+        suggested_by_id: user.id,
+        title: "Test Option",
+        status: "active"
+      })
+
+      # Create votes for the option (poll_option, user, vote_data, voting_system)
+      {:ok, _vote1} = Events.create_poll_vote(option, user, %{vote_value: "yes"}, "binary")
+      {:ok, _vote2} = Events.create_poll_vote(option, other_user, %{vote_value: "yes"}, "binary")
+
+      # Verify votes exist by checking the database directly
+      votes = EventasaurusApp.Repo.all(
+        from v in EventasaurusApp.Events.PollVote,
+        where: v.poll_option_id == ^option.id
+      )
+      assert length(votes) == 2
+
+      # Delete the option
+      {:ok, _deleted_option} = Events.delete_poll_option(option)
+
+      # Verify votes are also deleted
+      votes_after = EventasaurusApp.Repo.all(
+        from v in EventasaurusApp.Events.PollVote,
+        where: v.poll_option_id == ^option.id
+      )
+      assert length(votes_after) == 0
+    end
+  end
+
+  describe "time window deletion scenario" do
+    test "user can delete their suggestion within 5 minutes", %{poll: poll, user: user} do
+      # Create a suggestion
+      {:ok, option} = Events.create_poll_option(%{
+        poll_id: poll.id,
+        suggested_by_id: user.id,
+        title: "My Suggestion",
+        status: "active"
+      })
+
+      # Verify user can delete it
+      assert Events.can_delete_own_suggestion?(option, user) == true
+
+      # Delete it
+      assert {:ok, _} = Events.delete_poll_option(option)
+    end
+
+    test "poll creator can always delete any suggestion", %{poll: poll, user: creator, other_user: other_user} do
+      # Create a suggestion by other_user
+      {:ok, option} = Events.create_poll_option(%{
+        poll_id: poll.id,
+        suggested_by_id: other_user.id,
+        title: "Other User's Suggestion",
+        status: "active"
+      })
+
+      # Make the option old (beyond 5 minutes)
+      old_time = NaiveDateTime.utc_now()
+      |> NaiveDateTime.add(-600, :second)
+      |> NaiveDateTime.truncate(:second)
+      
+      Ecto.Changeset.change(option, %{inserted_at: old_time})
+      |> EventasaurusApp.Repo.update!()
+
+      option = EventasaurusApp.Repo.get!(PollOption, option.id)
+
+      # Creator should still be able to delete it (this test assumes creator authorization is handled elsewhere)
+      # The can_delete_own_suggestion? function only checks for own suggestions within time window
+      assert Events.can_delete_own_suggestion?(option, creator) == false
+      
+      # But deletion itself should still work if authorized
+      assert {:ok, _} = Events.delete_poll_option(option)
+    end
+  end
+end

--- a/test/support/fixtures/events_fixtures.ex
+++ b/test/support/fixtures/events_fixtures.ex
@@ -83,4 +83,50 @@ defmodule EventasaurusApp.EventsFixtures do
 
     participant
   end
+
+  @doc """
+  Generate a poll.
+  """
+  def poll_fixture(attrs \\ %{}) do
+    event = Map.get_lazy(attrs, :event, fn -> event_fixture() end)
+    user = Map.get_lazy(attrs, :user, fn -> EventasaurusApp.AccountsFixtures.user_fixture() end)
+
+    {:ok, poll} =
+      attrs
+      |> Enum.into(%{
+        event_id: event.id,
+        created_by_id: user.id,
+        title: "Test Poll",
+        description: "A test poll",
+        poll_type: "general",
+        voting_system: "binary",
+        phase: "list_building",
+        max_options_per_user: 3
+      })
+      |> Events.create_poll()
+
+    poll
+  end
+
+  @doc """
+  Generate a poll option.
+  """
+  def poll_option_fixture(attrs \\ %{}) do
+    poll = Map.get_lazy(attrs, :poll, fn -> poll_fixture() end)
+    user = Map.get_lazy(attrs, :user, fn -> EventasaurusApp.AccountsFixtures.user_fixture() end)
+
+    {:ok, poll_option} =
+      attrs
+      |> Enum.into(%{
+        poll_id: poll.id,
+        suggested_by_id: user.id,
+        title: "Test Option",
+        description: "A test option",
+        status: "active",
+        order_index: 0
+      })
+      |> Events.create_poll_option()
+
+    poll_option
+  end
 end


### PR DESCRIPTION
### TL;DR

Allow users to delete their own poll suggestions within a 5-minute window.

### What changed?

- Added a new `can_delete_own_suggestion?/2` function in the Events context that checks if a user can delete their own poll suggestion based on:
  - The user being the one who suggested the option
  - The option being created less than 5 minutes ago
- Updated the option suggestion component UI to:
  - Show a "Remove" button for users who suggested an option (within the time window)
  - Display a countdown timer showing how much time is left to delete the suggestion
  - Properly handle authorization when removing options
- Added comprehensive tests for the new functionality

### How to test?

1. Create a poll and have a participant suggest an option
2. Verify the participant can see a "Remove" button with a countdown timer
3. Verify they can delete their suggestion within the 5-minute window
4. Wait for 5 minutes and verify the delete option disappears
5. As the poll creator, verify you can delete any suggestion regardless of time

### Why make this change?

This change gives users a grace period to remove their own suggestions if they made a mistake or changed their mind, without needing the poll creator to intervene. The 5-minute window provides flexibility while preventing disruption to polls where voting may have already occurred on the suggestion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete their own poll option suggestions within 5 minutes of creation, with a visible countdown timer.
  * Poll creators retain the ability to remove any suggestion.
  * Deletion actions are broadcast to all participants for transparency.

* **Bug Fixes**
  * Unauthorized users attempting to delete suggestions now receive an appropriate error message.

* **Tests**
  * Added comprehensive tests for poll option deletion logic, including time-based and authorization scenarios.

* **Chores**
  * Introduced new test fixture helpers for polls and poll options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->