### PR TITLE
poll delettion

### DIFF
--- a/lib/eventasaurus_app/events.ex
+++ b/lib/eventasaurus_app/events.ex
@@ -2968,6 +2968,19 @@ defmodule EventasaurusApp.Events do
   end
 
   @doc """
+  Returns poll options by their IDs with specified preloads.
+  Only returns active options and filters out any missing records safely.
+  """
+  def list_poll_options_by_ids(option_ids, preloads \\ []) when is_list(option_ids) do
+    query = from po in PollOption,
+            where: po.id in ^option_ids and po.status == "active",
+            order_by: [asc: po.order_index, asc: po.inserted_at],
+            preload: ^preloads
+
+    Repo.all(query)
+  end
+
+  @doc """
   Gets a single poll option.
   """
   def get_poll_option!(id) do


### PR DESCRIPTION
### TL;DR

Added duplicate poll option detection and the ability for users to delete their own recently suggested poll options.

### What changed?

- Added duplicate poll option detection when users suggest new options
- Implemented the ability for users to delete their own poll option suggestions within a 5-minute window
- Added error handling for duplicate suggestions with different messages depending on whether the duplicate was suggested by the same user or another user
- Modified the `DateSelectionPollComponent` to support being embedded without container styling
- Updated the `VotingInterfaceComponent` to support hiding its header when embedded in other components

### How to test?

1. Try suggesting the same poll option twice in a poll - you should see an error message
2. Suggest a new poll option and verify you can delete it within 5 minutes
3. Verify the countdown timer shows the remaining time to delete your suggestion
4. Check that after 5 minutes, the delete option disappears
5. Verify that you cannot delete options suggested by other users

### Why make this change?

This change improves the user experience by preventing duplicate poll options and giving users control over their own suggestions. The 5-minute deletion window allows users to correct mistakes without permanently cluttering polls with unwanted options, while still maintaining the integrity of the voting process once other users have started voting on options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the loading of poll option details by switching to batch loading, resulting in faster and more efficient display of poll options and their associated information.
  * Enhanced performance when displaying or updating movie poll options and voting interfaces, especially for polls with many options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->