### PR TITLE
turnstile

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -26,6 +26,11 @@ config :stripity_stripe,
   api_key: System.get_env("STRIPE_SECRET_KEY"),
   connect_client_id: System.get_env("STRIPE_CONNECT_CLIENT_ID")
 
+# Configure Cloudflare Turnstile for bot protection
+config :eventasaurus, :turnstile,
+  site_key: System.get_env("TURNSTILE_SITE_KEY"),
+  secret_key: System.get_env("TURNSTILE_SECRET_KEY")
+
 # Configure Sentry for all environments (dev/test/prod)
 # Using runtime.exs ensures File.cwd() runs at startup, not compile time
 case System.get_env("SENTRY_DSN") do

--- a/lib/eventasaurus_app/services/turnstile.ex
+++ b/lib/eventasaurus_app/services/turnstile.ex
@@ -1,0 +1,83 @@
+defmodule EventasaurusApp.Services.Turnstile do
+  @moduledoc """
+  Module for verifying Cloudflare Turnstile tokens to prevent bot signups.
+  """
+
+  require Logger
+
+  @verify_endpoint "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+  @doc """
+  Verifies a Turnstile token with Cloudflare's API.
+  
+  Returns {:ok, true} if the token is valid, {:ok, false} if invalid,
+  or {:error, reason} if the verification fails.
+  """
+  def verify_token(token) when is_binary(token) do
+    config = Application.get_env(:eventasaurus, :turnstile, [])
+    
+    case config[:secret_key] do
+      nil ->
+        Logger.warning("Turnstile secret key not configured")
+        {:error, :not_configured}
+        
+      secret_key ->
+        perform_verification(token, secret_key)
+    end
+  end
+  
+  def verify_token(_), do: {:error, :invalid_token}
+
+  defp perform_verification(token, secret_key) do
+    body = URI.encode_query(%{
+      "secret" => secret_key,
+      "response" => token
+    })
+    
+    headers = [
+      {"Content-Type", "application/x-www-form-urlencoded"},
+      {"Accept", "application/json"}
+    ]
+    
+    case HTTPoison.post(@verify_endpoint, body, headers, timeout: 5000, recv_timeout: 5000) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: response_body}} ->
+        parse_verification_response(response_body)
+        
+      {:ok, %HTTPoison.Response{status_code: status_code}} ->
+        Logger.error("Turnstile API returned status #{status_code}")
+        {:error, :api_error}
+        
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        Logger.error("Turnstile verification failed: #{inspect(reason)}")
+        {:error, :network_error}
+    end
+  end
+  
+  defp parse_verification_response(body) do
+    case Jason.decode(body) do
+      {:ok, %{"success" => true}} ->
+        Logger.debug("Turnstile verification successful")
+        {:ok, true}
+        
+      {:ok, %{"success" => false, "error-codes" => errors}} ->
+        Logger.warning("Turnstile verification failed: #{inspect(errors)}")
+        {:ok, false}
+        
+      {:ok, %{"success" => false}} ->
+        Logger.warning("Turnstile verification failed (no error codes)")
+        {:ok, false}
+        
+      {:error, _} ->
+        Logger.error("Failed to parse Turnstile response")
+        {:error, :invalid_response}
+    end
+  end
+
+  @doc """
+  Checks if Turnstile is configured with both keys.
+  """
+  def enabled? do
+    config = Application.get_env(:eventasaurus, :turnstile, [])
+    config[:site_key] != nil && config[:secret_key] != nil
+  end
+end

--- a/lib/eventasaurus_web/components/layouts/root.html.heex
+++ b/lib/eventasaurus_web/components/layouts/root.html.heex
@@ -72,6 +72,12 @@
     <!-- Alpine.js for interactive components -->
     <script defer src="https://unpkg.com/alpinejs@3.14.1/dist/cdn.min.js" integrity="sha384-l8f0VcPi/M1iHPv8egOnY/15TDwqgbOR1anMIJWvU6nLRgZVLTLSaNqi/TOoT5Fh" crossorigin="anonymous"></script>
     
+    <!-- Cloudflare Turnstile for bot protection -->
+    <% turnstile_config = Application.get_env(:eventasaurus, :turnstile, []) %>
+    <%= if turnstile_config[:site_key] do %>
+      <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    <% end %>
+    
     <!-- Supabase configuration meta tags -->
     <meta name="supabase-url" content={supabase_url} />
     <meta name="supabase-anon-key" content={supabase_api_key} />

--- a/lib/eventasaurus_web/controllers/auth/auth_html/register.html.heex
+++ b/lib/eventasaurus_web/controllers/auth/auth_html/register.html.heex
@@ -80,6 +80,20 @@
           />
         </div>
 
+        <!-- Cloudflare Turnstile Widget -->
+        <% turnstile_config = Application.get_env(:eventasaurus, :turnstile, []) %>
+        <%= if turnstile_config[:site_key] do %>
+          <div class="flex justify-center">
+            <div 
+              class="cf-turnstile" 
+              data-sitekey={turnstile_config[:site_key]}
+              data-theme="light"
+              data-appearance="always"
+              data-size="normal"
+            ></div>
+          </div>
+        <% end %>
+
         <div class="pt-2">
           <button
             type="submit"

--- a/lib/eventasaurus_web/plugs/csp_plug.ex
+++ b/lib/eventasaurus_web/plugs/csp_plug.ex
@@ -1,0 +1,38 @@
+defmodule EventasaurusWeb.Plugs.CSPPlug do
+  @moduledoc """
+  Content Security Policy plug that configures allowed sources for various content types.
+  """
+
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    csp_header = build_csp_header()
+    put_resp_header(conn, "content-security-policy", csp_header)
+  end
+
+  defp build_csp_header do
+    # Base CSP directives
+    directives = %{
+      "default-src" => "'self'",
+      "script-src" => "'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://js.stripe.com https://challenges.cloudflare.com https://maps.googleapis.com https://maps.gstatic.com",
+      "style-src" => "'self' 'unsafe-inline' https://fonts.googleapis.com",
+      "font-src" => "'self' https://fonts.gstatic.com data:",
+      "img-src" => "'self' data: blob: https: http:",
+      "connect-src" => "'self' https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://challenges.cloudflare.com https://maps.googleapis.com https://eu.i.posthog.com",
+      "frame-src" => "'self' https://js.stripe.com https://challenges.cloudflare.com",
+      "frame-ancestors" => "'none'",
+      "object-src" => "'none'",
+      "base-uri" => "'self'",
+      "form-action" => "'self'",
+      "worker-src" => "'self' blob:",
+      "child-src" => "'self' blob:"
+    }
+
+    # Convert to CSP header string
+    directives
+    |> Enum.map(fn {directive, sources} -> "#{directive} #{sources}" end)
+    |> Enum.join("; ")
+  end
+end

--- a/lib/eventasaurus_web/router.ex
+++ b/lib/eventasaurus_web/router.ex
@@ -15,6 +15,7 @@ defmodule EventasaurusWeb.Router do
     plug :put_root_layout, html: {EventasaurusWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug EventasaurusWeb.Plugs.CSPPlug
     plug :fetch_auth_user
     plug :assign_user_struct
   end


### PR DESCRIPTION
### TL;DR

Added Cloudflare Turnstile integration for bot protection on the registration page.

### What changed?

- Integrated Cloudflare Turnstile to protect against bot registrations
- Created a new `Turnstile` service module for token verification
- Added Turnstile widget to the registration form
- Implemented verification logic in the auth controller
- Added configuration for Turnstile site and secret keys
- Created a Content Security Policy plug to allow Cloudflare resources
- Updated CSP headers to permit Turnstile scripts and connections

### How to test?

1. Set the environment variables `TURNSTYLE_SITE_KEY` and `TURNSTYLE_SECRET_KEY` with your Cloudflare Turnstile credentials
2. Visit the registration page and verify the Turnstile widget appears
3. Try to register without completing the Turnstile challenge - it should fail
4. Complete the Turnstile challenge and verify registration works correctly
5. Verify the CSP headers allow Cloudflare resources to load properly

### Why make this change?

This integration adds protection against automated bot registrations, which helps prevent spam accounts and abuse. Cloudflare Turnstile provides a user-friendly CAPTCHA alternative that improves security while maintaining a good user experience. The CSP plug ensures proper security headers while allowing the necessary external resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Turnstile bot protection to the user registration form, including a verification widget and backend validation.
  * Introduced Content Security Policy (CSP) headers for enhanced web security.

* **Bug Fixes**
  * Registration now blocks submissions identified as bot activity when Turnstile is enabled.

* **Chores**
  * Updated configuration to support Turnstile integration and CSP enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->