### PR TITLE
working better

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -29,7 +29,11 @@ config :stripity_stripe,
 # Configure Cloudflare Turnstile for bot protection
 config :eventasaurus, :turnstile,
   site_key: System.get_env("TURNSTILE_SITE_KEY"),
-  secret_key: System.get_env("TURNSTILE_SECRET_KEY")
+  secret_key: System.get_env("TURNSTILE_SECRET_KEY"),
+  # Optional configuration (defaults shown)
+  theme: System.get_env("TURNSTILE_THEME", "light"),        # "light", "dark", "auto"
+  appearance: System.get_env("TURNSTILE_APPEARANCE", "always"),  # "always", "execute", "interaction-only"
+  size: System.get_env("TURNSTILE_SIZE", "normal")         # "normal", "compact"
 
 # Configure Sentry for all environments (dev/test/prod)
 # Using runtime.exs ensures File.cwd() runs at startup, not compile time

--- a/lib/eventasaurus_web/controllers/auth/auth_html.ex
+++ b/lib/eventasaurus_web/controllers/auth/auth_html.ex
@@ -1,7 +1,7 @@
 defmodule EventasaurusWeb.Auth.AuthHTML do
   use EventasaurusWeb, :html
 
-  embed_templates "auth_html/*", suffix: "_template"
+  # Note: Template files were removed as they're replaced by function components below
 
   # Define the required flash attribute for the flash_messages function
   attr :flash, :map, required: true
@@ -108,9 +108,9 @@ defmodule EventasaurusWeb.Auth.AuthHTML do
             <div 
               class="cf-turnstile" 
               data-sitekey={turnstile_config[:site_key]}
-              data-theme="light"
-              data-appearance="always"
-              data-size="normal"
+              data-theme={turnstile_config[:theme] || "light"}
+              data-appearance={turnstile_config[:appearance] || "always"}
+              data-size={turnstile_config[:size] || "normal"}
             ></div>
           </div>
         <% end %>


### PR DESCRIPTION
### TL;DR

Enhanced Cloudflare Turnstile configuration with customizable appearance options.

### What changed?

- Added optional configuration parameters for Cloudflare Turnstile in `config/runtime.exs`:
  - `theme`: Controls the color scheme (light, dark, auto)
  - `appearance`: Controls when the widget appears (always, execute, interaction-only)
  - `size`: Controls the widget size (normal, compact)
- Updated the Turnstile component in `auth_html.ex` to use these configurable parameters
- Removed template files as they've been replaced by function components

### How to test?

1. Set any of the new environment variables (`TURNSTILE_THEME`, `TURNSTILE_APPEARANCE`, `TURNSTILE_SIZE`) to test different configurations
2. Verify the Turnstile widget renders with the specified appearance settings
3. Test with different combinations to ensure the widget adapts correctly

### Why make this change?

This change provides greater flexibility for customizing the Cloudflare Turnstile widget to match the application's design and UX requirements. By making these appearance options configurable through environment variables, we can easily adjust the widget's look and feel without code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to customize the Cloudflare Turnstile widget’s theme, appearance, and size through environment variables.

* **Refactor**
  * Updated the registration page so that Turnstile widget settings are now dynamically loaded from configuration, allowing for easier customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->