### PR TITLE
fixes

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -27,13 +27,22 @@ config :stripity_stripe,
   connect_client_id: System.get_env("STRIPE_CONNECT_CLIENT_ID")
 
 # Configure Cloudflare Turnstile for bot protection
+# Helper function to handle empty env vars
+get_env_with_default = fn var, default ->
+  case System.get_env(var) do
+    nil -> default
+    "" -> default
+    value -> value
+  end
+end
+
 config :eventasaurus, :turnstile,
   site_key: System.get_env("TURNSTILE_SITE_KEY"),
   secret_key: System.get_env("TURNSTILE_SECRET_KEY"),
   # Optional configuration (defaults shown)
-  theme: System.get_env("TURNSTILE_THEME", "light"),        # "light", "dark", "auto"
-  appearance: System.get_env("TURNSTILE_APPEARANCE", "always"),  # "always", "execute", "interaction-only"
-  size: System.get_env("TURNSTILE_SIZE", "normal")         # "normal", "compact"
+  theme: get_env_with_default.("TURNSTILE_THEME", "light"),        # "light", "dark", "auto"
+  appearance: get_env_with_default.("TURNSTILE_APPEARANCE", "execute"),  # "always", "execute", "interaction-only"
+  size: get_env_with_default.("TURNSTILE_SIZE", "normal")         # "normal", "compact"
 
 # Configure Sentry for all environments (dev/test/prod)
 # Using runtime.exs ensures File.cwd() runs at startup, not compile time

--- a/lib/eventasaurus_web/controllers/auth/auth_html.ex
+++ b/lib/eventasaurus_web/controllers/auth/auth_html.ex
@@ -3,6 +3,11 @@ defmodule EventasaurusWeb.Auth.AuthHTML do
 
   # Note: Template files were removed as they're replaced by function components below
 
+  # Helper to handle empty strings
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(value), do: value
+
   # Define the required flash attribute for the flash_messages function
   attr :flash, :map, required: true
 
@@ -108,9 +113,9 @@ defmodule EventasaurusWeb.Auth.AuthHTML do
             <div 
               class="cf-turnstile" 
               data-sitekey={turnstile_config[:site_key]}
-              data-theme={turnstile_config[:theme] || "light"}
-              data-appearance={turnstile_config[:appearance] || "always"}
-              data-size={turnstile_config[:size] || "normal"}
+              data-theme={presence(turnstile_config[:theme]) || "light"}
+              data-appearance={presence(turnstile_config[:appearance]) || "execute"}
+              data-size={presence(turnstile_config[:size]) || "normal"}
             ></div>
           </div>
         <% end %>


### PR DESCRIPTION
### TL;DR

Improved handling of empty environment variables for Turnstile configuration and updated default appearance setting.

### What changed?

- Added a `get_env_with_default` helper function in `runtime.exs` to properly handle nil and empty string environment variables
- Changed the default Turnstile appearance from "always" to "execute"
- Added a `presence/1` helper function in `auth_html.ex` to handle empty strings in Turnstile configuration
- Updated the Turnstile widget to use these improved configuration handlers

### How to test?

1. Test with various environment variable configurations:
   - Set no Turnstile environment variables
   - Set empty values for Turnstile variables
   - Set specific values for Turnstile variables
2. Verify the Turnstile widget appears correctly with the "execute" appearance by default
3. Verify the widget respects custom configurations when provided

### Why make this change?

The previous implementation didn't properly handle empty environment variables, which could lead to unexpected behavior. Additionally, changing the default appearance from "always" to "execute" provides a better user experience as the Turnstile challenge only appears when needed rather than being constantly visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of Cloudflare Turnstile widget settings in the registration form, ensuring that empty or unset environment variables are treated consistently.
  
* **Bug Fixes**
  * Fixed an issue where empty string values for Turnstile configuration could override defaults, leading to unintended widget behavior.

* **Chores**
  * Updated the default value for the Turnstile widget's appearance setting from "always" to "execute".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->