### PR TITLE
working

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -27,22 +27,9 @@ config :stripity_stripe,
   connect_client_id: System.get_env("STRIPE_CONNECT_CLIENT_ID")
 
 # Configure Cloudflare Turnstile for bot protection
-# Helper function to handle empty env vars
-get_env_with_default = fn var, default ->
-  case System.get_env(var) do
-    nil -> default
-    "" -> default
-    value -> value
-  end
-end
-
 config :eventasaurus, :turnstile,
   site_key: System.get_env("TURNSTILE_SITE_KEY"),
-  secret_key: System.get_env("TURNSTILE_SECRET_KEY"),
-  # Optional configuration (defaults shown)
-  theme: get_env_with_default.("TURNSTILE_THEME", "light"),        # "light", "dark", "auto"
-  appearance: get_env_with_default.("TURNSTILE_APPEARANCE", "execute"),  # "always", "execute", "interaction-only"
-  size: get_env_with_default.("TURNSTILE_SIZE", "normal")         # "normal", "compact"
+  secret_key: System.get_env("TURNSTILE_SECRET_KEY")
 
 # Configure Sentry for all environments (dev/test/prod)
 # Using runtime.exs ensures File.cwd() runs at startup, not compile time

--- a/lib/eventasaurus_web/controllers/auth/auth_html.ex
+++ b/lib/eventasaurus_web/controllers/auth/auth_html.ex
@@ -3,11 +3,6 @@ defmodule EventasaurusWeb.Auth.AuthHTML do
 
   # Note: Template files were removed as they're replaced by function components below
 
-  # Helper to handle empty strings
-  defp presence(nil), do: nil
-  defp presence(""), do: nil
-  defp presence(value), do: value
-
   # Define the required flash attribute for the flash_messages function
   attr :flash, :map, required: true
 
@@ -113,9 +108,9 @@ defmodule EventasaurusWeb.Auth.AuthHTML do
             <div 
               class="cf-turnstile" 
               data-sitekey={turnstile_config[:site_key]}
-              data-theme={presence(turnstile_config[:theme]) || "light"}
-              data-appearance={presence(turnstile_config[:appearance]) || "execute"}
-              data-size={presence(turnstile_config[:size]) || "normal"}
+              data-theme="light"
+              data-appearance="interaction-only"
+              data-size="normal"
             ></div>
           </div>
         <% end %>


### PR DESCRIPTION
### TL;DR

Simplified Turnstile configuration by removing optional parameters and helper functions.

### What changed?

- Removed the `get_env_with_default` helper function from `runtime.exs`
- Removed optional Turnstile configuration parameters (theme, appearance, size) from the config
- Removed the `presence/1` helper function from `auth_html.ex`
- Hardcoded Turnstile widget parameters directly in the HTML template:
  - Set theme to "light"
  - Changed appearance from "execute" to "interaction-only"
  - Set size to "normal"

### How to test?

1. Verify that the Turnstile widget still appears correctly on authentication pages
2. Test the authentication flow to ensure the Turnstile challenge works properly
3. Check that the widget has the correct appearance (light theme, normal size)
4. Verify that the widget appears during user interaction

### Why make this change?

This change simplifies the codebase by removing unnecessary helper functions and configuration options. By hardcoding reasonable defaults directly in the template, we reduce complexity while maintaining the same functionality. The "interaction-only" appearance setting provides a better user experience by only showing the challenge when users interact with the form.