### PR TITLE
final changes

### DIFF
--- a/lib/eventasaurus/services/anonymous_id_service.ex
+++ b/lib/eventasaurus/services/anonymous_id_service.ex
@@ -43,7 +43,8 @@ defmodule Eventasaurus.Services.AnonymousIdService do
   def generate_anonymous_id do
     # Use microsecond timestamp for better uniqueness
     timestamp = System.os_time(:microsecond)
-    random_component = :rand.uniform(999_999)
+    # Use :crypto for better randomness and more entropy (48 bits)
+    random_component = :crypto.strong_rand_bytes(6) |> Base.encode16(case: :lower)
     
     "anon_#{timestamp}_#{random_component}"
   end
@@ -70,6 +71,10 @@ defmodule Eventasaurus.Services.AnonymousIdService do
   
   def get_user_identifier(user_id, _socket_or_session) when is_binary(user_id) and user_id != "" do
     user_id
+  end
+  
+  def get_user_identifier(user_id, _socket_or_session) when is_integer(user_id) do
+    to_string(user_id)
   end
   
   def get_user_identifier(_user_id, socket_or_session) do


### PR DESCRIPTION
# Improved Anonymous ID Generation and User Identifier Handling

### TL;DR

Enhanced anonymous ID generation with stronger randomness and fixed user identifier handling for integer user IDs.

### What changed?

- Replaced the simple `:rand.uniform` with `:crypto.strong_rand_bytes` for generating anonymous IDs, providing better randomness and increased entropy (48 bits)
- Added a new `get_user_identifier/2` function clause to handle integer user IDs by converting them to strings
- Fixed the order of operations in the voting interface component to ensure anonymous IDs are assigned before they're used

### How to test?

1. Verify anonymous users can still vote on polls
2. Check that integer user IDs are properly handled when tracking poll views
3. Confirm that anonymous IDs are being generated with the new format (should include a longer hexadecimal component)

### Why make this change?

The previous random component in anonymous IDs had limited entropy, potentially leading to collisions. Using cryptographically strong random bytes significantly reduces this risk. Additionally, the code was failing to properly handle integer user IDs and had a timing issue where anonymous IDs might be used before being assigned.