### PR TITLE
getting closer

### DIFF
--- a/lib/eventasaurus_app/events.ex
+++ b/lib/eventasaurus_app/events.ex
@@ -988,8 +988,15 @@ defmodule EventasaurusApp.Events do
           order_by: [desc: coalesce(e.start_at, e.inserted_at)],
           limit: ^limit
       :archived ->
+<<<<<<< HEAD
         # Archived events are already filtered at the query level
         from e in subquery(union_query),
+=======
+        # TODO: Implement proper archived events using soft-deleted entries
+        # For now, return empty result set
+        from e in subquery(union_query), 
+          where: false,
+>>>>>>> 19793db (getting closer)
           order_by: [desc: coalesce(e.start_at, e.inserted_at)],
           limit: ^limit
       :all -> 

--- a/lib/eventasaurus_web/live/dashboard_live.ex
+++ b/lib/eventasaurus_web/live/dashboard_live.ex
@@ -155,7 +155,11 @@ defmodule EventasaurusWeb.DashboardLive do
     filter_counts = %{
       upcoming: count_events_by_filter(user, :upcoming, :all),
       past: count_events_by_filter(user, :past, :all),
+<<<<<<< HEAD
       archived: count_archived_events(user),
+=======
+      archived: count_events_by_filter(user, :archived, :all),
+>>>>>>> 19793db (getting closer)
       created: count_events_by_filter(user, :all, :created),
       participating: count_events_by_filter(user, :all, :participating)
     }


### PR DESCRIPTION
### TL;DR

Temporarily disable archived events functionality by returning an empty result set.

### What changed?

- Modified the `:archived` case in the query builder to return an empty result set instead of using the existing implementation
- Added a TODO comment explaining that proper archived events will be implemented using soft-deleted entries in the future
- Updated the `count_archived_events` function call in `dashboard_live.ex` to use the standard `count_events_by_filter` function with the `:archived` filter

### How to test?

1. Navigate to the dashboard and verify that the archived events tab shows zero events
2. Confirm that the count for archived events is zero in the dashboard filters
3. Verify that other event filters (upcoming, past, created, participating) continue to work as expected

### Why make this change?

This is an interim solution while working toward a proper implementation of archived events using soft deletion. The current implementation of archived events doesn't correctly filter at the query level, so this change prevents showing incorrect data until the proper implementation is completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived events are no longer displayed or counted in the dashboard, ensuring that the archived events filter returns zero results until further updates.

* **Chores**
  * Updated internal logic for calculating archived event counts to align with unified event filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->