### PR TITLE
perfectly tall

### DIFF
--- a/lib/eventasaurus_web/live/dashboard_live.html.heex
+++ b/lib/eventasaurus_web/live/dashboard_live.html.heex
@@ -315,7 +315,7 @@
                         </div>
                         
                         <!-- Event Image -->
-                        <div class="w-full sm:w-56 h-32 sm:h-auto sm:self-stretch rounded-lg overflow-hidden flex-shrink-0">
+                        <div class="w-full sm:w-64 h-44 sm:h-44 rounded-lg overflow-hidden flex-shrink-0">
                           <%= if event.cover_image_url do %>
                             <img src={event.cover_image_url} alt={event.title} class="w-full h-full object-cover">
                           <% else %>


### PR DESCRIPTION
### TL;DR

Adjusted the event image dimensions in the dashboard view for better display proportions.

### What changed?

- Modified the event image container dimensions from `w-full sm:w-56 h-32 sm:h-auto` to `w-full sm:w-64 h-44 sm:h-44`
- Removed the `sm:self-stretch` class from the image container
- This creates a larger, more consistently sized image display across different screen sizes

### How to test?

1. Navigate to the dashboard page
2. Verify that event images now display in a larger 64x44 pixel format on desktop
3. Confirm that images maintain a consistent height on both mobile and desktop views
4. Check that the images still render properly within their containers

### Why make this change?

The previous image dimensions were inconsistent across breakpoints, with variable height on desktop. This change provides a more visually balanced presentation of event images with fixed dimensions, improving the overall aesthetic of the dashboard and ensuring consistent image display regardless of device size.