### PR TITLE
fix the last bugs

### DIFF
--- a/lib/eventasaurus_web/live/dashboard_live.html.heex
+++ b/lib/eventasaurus_web/live/dashboard_live.html.heex
@@ -267,11 +267,27 @@
                             </div>
                             
                             <!-- Participants with Avatars -->
-                            <%= if (event.participant_count && event.participant_count > 0) do %>
+                            <% 
+                              # Calculate the actual participant count from available data
+                              actual_count = cond do
+                                # If we have participant_count, use it as the source of truth
+                                is_integer(event.participant_count) && event.participant_count >= 0 -> event.participant_count
+                                # If we have participants array, use its length as fallback
+                                is_list(event.participants) -> length(event.participants)
+                                # Otherwise default to 0
+                                true -> 0
+                              end
+                              
+                              # Determine how many more participants there are beyond what's shown
+                              participants_list = event.participants || []
+                              shown_count = min(length(participants_list), 3)
+                              more_count = max(actual_count - shown_count, 0)
+                            %>
+                            <%= if actual_count > 0 || length(participants_list) > 0 do %>
                               <div class="flex items-center">
-                                <%= if event.participants && length(event.participants) > 0 do %>
+                                <%= if length(participants_list) > 0 do %>
                                   <div class="flex -space-x-1.5 mr-2">
-                                    <%= for {participant, _index} <- Enum.with_index(Enum.take(event.participants, 3)) do %>
+                                    <%= for {participant, _index} <- Enum.with_index(Enum.take(participants_list, 3)) do %>
                                       <%= if participant.user do %>
                                         <div class="relative group">
                                           <img 
@@ -287,14 +303,14 @@
                                         </div>
                                       <% end %>
                                     <% end %>
-                                    <%= if length(event.participants) > 3 do %>
+                                    <%= if more_count > 0 do %>
                                       <div class="relative group">
                                         <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-gray-600 text-xs font-medium border-2 border-white hover:z-20 hover:scale-110 transition-transform cursor-pointer">
-                                          +<%= length(event.participants) - 3 %>
+                                          +<%= more_count %>
                                         </div>
                                         <!-- Tooltip -->
                                         <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-xs rounded whitespace-nowrap opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50 pointer-events-none">
-                                          <%= length(event.participants) - 3 %> more participants
+                                          <%= more_count %> more participants
                                           <div class="absolute top-full left-1/2 transform -translate-x-1/2 -mt-1 border-4 border-transparent border-t-gray-900"></div>
                                         </div>
                                       </div>
@@ -302,7 +318,7 @@
                                   </div>
                                 <% end %>
                                 <span class="text-sm text-gray-600">
-                                  <%= event.participant_count || 0 %> attending
+                                  <%= actual_count %> attending
                                 </span>
                               </div>
                             <% else %>
@@ -488,11 +504,27 @@
                         </div>
                         
                         <!-- Participants with Avatars -->
-                        <%= if (event.participant_count && event.participant_count > 0) do %>
+                        <% 
+                          # Calculate the actual participant count from available data
+                          actual_count = cond do
+                            # If we have participant_count, use it as the source of truth
+                            is_integer(event.participant_count) && event.participant_count >= 0 -> event.participant_count
+                            # If we have participants array, use its length as fallback
+                            is_list(event.participants) -> length(event.participants)
+                            # Otherwise default to 0
+                            true -> 0
+                          end
+                          
+                          # Determine how many more participants there are beyond what's shown
+                          participants_list = event.participants || []
+                          shown_count = min(length(participants_list), 3)
+                          more_count = max(actual_count - shown_count, 0)
+                        %>
+                        <%= if actual_count > 0 || length(participants_list) > 0 do %>
                           <div class="flex items-center">
-                            <%= if event.participants && length(event.participants) > 0 do %>
+                            <%= if length(participants_list) > 0 do %>
                               <div class="flex -space-x-1.5 mr-2">
-                                <%= for participant <- Enum.take(event.participants, 3) do %>
+                                <%= for participant <- Enum.take(participants_list, 3) do %>
                                   <%= if participant.user do %>
                                     <img 
                                       src={EventasaurusApp.Accounts.User.avatar_url(participant.user, %{size: 40})}
@@ -502,15 +534,15 @@
                                     >
                                   <% end %>
                                 <% end %>
-                                <%= if length(event.participants) > 3 do %>
-                                  <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-gray-600 text-xs font-medium border-2 border-white hover:z-10 hover:scale-110 transition-transform cursor-pointer" title={"#{length(event.participants) - 3} more participants"}>
-                                    +<%= length(event.participants) - 3 %>
+                                <%= if more_count > 0 do %>
+                                  <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-gray-600 text-xs font-medium border-2 border-white hover:z-10 hover:scale-110 transition-transform cursor-pointer" title={"#{more_count} more participants"}>
+                                    +<%= more_count %>
                                   </div>
                                 <% end %>
                               </div>
                             <% end %>
                             <span class="text-sm text-gray-600">
-                              <%= event.participant_count || 0 %> attending
+                              <%= actual_count %> attending
                             </span>
                           </div>
                         <% else %>


### PR DESCRIPTION
### TL;DR

Improved participant count display logic in the dashboard to handle edge cases and inconsistencies.

### What changed?

- Added robust logic to calculate the actual participant count using a fallback strategy:
  - First uses `event.participant_count` if it's a valid integer
  - Falls back to the length of `event.participants` array if available
  - Defaults to 0 if neither is valid
- Fixed the "more participants" counter to accurately reflect the difference between total participants and those shown
- Improved the display condition to show participants section when either count is greater than 0
- Applied these changes consistently in both instances of the participant display in the dashboard

### How to test?

1. View events with various participant scenarios:
   - Events with both `participant_count` and `participants` array
   - Events with only `participant_count` but no `participants` array
   - Events with only `participants` array but no `participant_count`
   - Events with no participants
2. Verify that the participant count displays correctly in all cases
3. Check that the "+X more" indicator shows the correct number when there are more than 3 participants

### Why make this change?

This change addresses inconsistencies in how participant counts were displayed, particularly when there were discrepancies between the `participant_count` field and the actual `participants` array. The improved logic ensures a more reliable display of participant information and handles edge cases gracefully, providing a better user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of participant counts displayed in both desktop and mobile views of the dashboard.
  * Participant avatars and "+N more" badges now correctly reflect the actual number of participants, even when some data is missing or inconsistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->