### PR TITLE
bug fix for group

### DIFF
--- a/lib/eventasaurus_web/components/event_components.ex
+++ b/lib/eventasaurus_web/components/event_components.ex
@@ -796,7 +796,7 @@ defmodule EventasaurusWeb.EventComponents do
               >
                 <option value="">No group - personal event</option>
                 <%= for group <- @user_groups do %>
-                  <option value={group.id} selected={group.id == @form_data["group_id"]}>
+                  <option value={group.id} selected={to_string(group.id) == to_string(@form_data["group_id"] || "")}>
                     <%= group.name %>
                   </option>
                 <% end %>


### PR DESCRIPTION
### TL;DR

Fixed group selection in event creation form to properly handle string/integer type conversions.

### What changed?

- Fixed the comparison in the event form dropdown to properly convert group IDs to strings before comparison
- Updated the event creation flow to ensure the selected group ID is properly stored in both the form data and the changeset
- Added handling for empty group_id values with a fallback to an empty string

### How to test?

1. Navigate to the event creation page
2. Test selecting different groups from the dropdown
3. Test creating an event with a pre-selected group (by passing group_id in URL params)
4. Verify that the correct group remains selected throughout the form submission process

### Why make this change?

The previous implementation had type comparison issues between string and integer group IDs, causing selected groups to not display correctly in the dropdown. This fix ensures consistent type handling by converting all IDs to strings before comparison, preventing the UI from losing the selected group during form interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the group assignment dropdown in the event form to correctly highlight the selected group, regardless of data type mismatches.
  * Ensured that the selected group is consistently pre-filled in the event form when accessed with a valid group ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->