### PR TITLE
small fix archive

### DIFF
--- a/lib/eventasaurus_web/components/events/event_card.ex
+++ b/lib/eventasaurus_web/components/events/event_card.ex
@@ -18,7 +18,7 @@ defmodule EventasaurusWeb.Components.Events.EventCard do
     
     ~H"""
     <article class="bg-white rounded-lg border shadow-sm hover:shadow-md transition-shadow" role="article" aria-labelledby={"event-title-#{@unique_id}"}>
-      <a href={get_event_url(@event, @context)} class="block" aria-label={"View #{@event.title}"}>
+      <a href={~p"/#{@event.slug}"} class="block" aria-label={"View #{@event.title}"}>
         <div class={card_padding(@layout)}>
           <!-- Event Header with Image -->
           <div class={card_layout(@layout)}>
@@ -99,7 +99,7 @@ defmodule EventasaurusWeb.Components.Events.EventCard do
       <!-- Actions -->
       <div class={action_padding(@layout) <> " flex flex-col sm:flex-row sm:items-center sm:justify-between border-t border-gray-100 gap-2 sm:gap-0"}>
           <div class="flex items-center flex-wrap gap-2">
-            <%= render_action_button(@event, @context) %>
+            <%= render_action_button(@event) %>
           </div>
           
           <!-- Participant Status Update (for non-organizers in user context) -->
@@ -129,16 +129,6 @@ defmodule EventasaurusWeb.Components.Events.EventCard do
   end
 
   # Helper functions
-  
-  defp get_event_url(event, :user_dashboard) do
-    if Map.get(event, :can_manage, false) do
-      "/events/#{event.slug}"
-    else
-      "/#{event.slug}"
-    end
-  end
-  
-  defp get_event_url(event, _), do: "/#{event.slug}"
 
   defp card_padding(:desktop), do: "p-3"
   defp card_padding(:mobile), do: "p-4"
@@ -155,34 +145,31 @@ defmodule EventasaurusWeb.Components.Events.EventCard do
   defp image_container_class(:desktop), do: "w-full sm:w-64 h-44 sm:h-44 rounded-lg overflow-hidden flex-shrink-0"
   defp image_container_class(:mobile), do: "w-16 h-16 rounded-lg overflow-hidden flex-shrink-0"
 
-  defp render_action_button(event, context) do
-    case {context, Map.get(event, :can_manage, false)} do
-      {:user_dashboard, true} ->
-        assigns = %{event: event}
-        ~H"""
-        <a 
-          href={~p"/events/#{@event.slug}"}
-          class="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded text-blue-700 bg-blue-100 hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-blue-500 relative z-10"
-          aria-label={"Manage #{@event.title}"}
-          onclick="event.stopPropagation()"
-        >
-          Manage
-        </a>
-        """
-      
-      {_, _} ->
-        assigns = %{event: event}
-        ~H"""
-        <a 
-          href={~p"/#{@event.slug}"}
-          class="inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 relative z-10"
-          aria-label={"View #{@event.title}"}
-          onclick="event.stopPropagation()"
-        >
-          View
-        </a>
-        """
-    end
+  defp render_action_button(event) do
+    can_manage = Map.get(event, :can_manage, false)
+    assigns = %{event: event, can_manage: can_manage}
+    
+    ~H"""
+    <%= if @can_manage do %>
+      <a 
+        href={~p"/events/#{@event.slug}"}
+        class="inline-flex items-center px-3 py-2 border border-transparent text-sm font-medium rounded text-blue-700 bg-blue-100 hover:bg-blue-200 focus:outline-none focus:ring-2 focus:ring-blue-500 relative z-10"
+        aria-label={"Manage #{@event.title}"}
+        onclick="event.stopPropagation()"
+      >
+        Manage
+      </a>
+    <% end %>
+    
+    <a 
+      href={~p"/#{@event.slug}"}
+      class="inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 relative z-10"
+      aria-label={"View #{@event.title}"}
+      onclick="event.stopPropagation()"
+    >
+      View
+    </a>
+    """
   end
 
   defp format_time(nil, _timezone), do: "Time TBD"

--- a/lib/eventasaurus_web/components/events/event_card_badges.ex
+++ b/lib/eventasaurus_web/components/events/event_card_badges.ex
@@ -30,7 +30,7 @@ defmodule EventasaurusWeb.Components.Events.EventCardBadges do
         </span>
       <% end %>
 
-      <%= if @context == :user_dashboard && @event.group && @event.group.slug do %>
+      <%= if @context == :user_dashboard && group_loaded?(@event) && @event.group do %>
         <a 
           href={"/groups/#{@event.group.slug}"} 
           class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 hover:bg-purple-200 transition-colors relative z-10" 
@@ -47,6 +47,13 @@ defmodule EventasaurusWeb.Components.Events.EventCardBadges do
   end
 
   # Helper functions
+
+  defp group_loaded?(event) do
+    case event.group do
+      %Ecto.Association.NotLoaded{} -> false
+      _ -> true
+    end
+  end
 
   defp role_badge_class("organizer"), do: "bg-green-100 text-green-800"
   defp role_badge_class("participant"), do: "bg-blue-100 text-blue-800"


### PR DESCRIPTION
### TL;DR

Simplified event card navigation and improved group event context handling.

### What changed?

- Simplified the event URL generation by using the `~p` sigil directly with the event slug
- Refactored the `render_action_button` function to use conditional rendering instead of pattern matching
- Added proper handling for group associations that might not be loaded
- Enhanced the group show page to add user context to events (roles and permissions)
- Fixed a bug where events in group pages weren't showing proper user context

### How to test?

1. Visit the user dashboard and verify that event cards show the correct action buttons
2. Check that "Manage" buttons appear only for events where the user is an organizer
3. Visit a group page and confirm that events display the correct user role badges
4. Verify that clicking on event cards navigates to the correct URL
5. Test with both loaded and unloaded group associations to ensure no errors occur

### Why make this change?

This change improves code maintainability by simplifying URL generation and action button rendering logic. It also fixes a bug where user context (like organizer status) wasn't properly applied to events displayed on group pages, ensuring consistent user experience across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events now display user-specific context, showing whether you can manage an event and your role (organizer or participant).

* **Refactor**
  * Simplified event link generation and action button logic for a more consistent user experience.
  * Improved badge display logic to more reliably show group badges when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->