### PR TITLE
fixes again

### DIFF
--- a/lib/eventasaurus_web/components/events/event_card_badges.ex
+++ b/lib/eventasaurus_web/components/events/event_card_badges.ex
@@ -30,7 +30,7 @@ defmodule EventasaurusWeb.Components.Events.EventCardBadges do
         </span>
       <% end %>
 
-      <%= if @context == :user_dashboard && group_loaded?(@event) && @event.group do %>
+      <%= if @context == :user_dashboard && group_loaded?(@event) && @event.group && @event.group.slug do %>
         <a 
           href={"/groups/#{@event.group.slug}"} 
           class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 hover:bg-purple-200 transition-colors relative z-10" 

--- a/lib/eventasaurus_web/live/group_live/show.ex
+++ b/lib/eventasaurus_web/live/group_live/show.ex
@@ -468,7 +468,11 @@ defmodule EventasaurusWeb.GroupLive.Show do
   defp add_user_context_to_events(events, user) do
     Enum.map(events, fn event ->
       # Check if user is an organizer of this event
-      is_organizer = event.users && Enum.any?(event.users, &(&1.id == user.id))
+      is_organizer = case event.users do
+        %Ecto.Association.NotLoaded{} -> false
+        users when is_list(users) -> Enum.any?(users, &(&1.id == user.id))
+        _ -> false
+      end
       
       event
       |> Map.put(:can_manage, is_organizer)


### PR DESCRIPTION
### TL;DR

Fixed two bugs related to event handling and group associations.

### What changed?

- Added a check for `@event.group.slug` in the event card badges component to prevent errors when a group exists but has no slug
- Fixed the `add_user_context_to_events` function to properly handle cases where the `users` association is not loaded, preventing potential errors when determining if a user is an organizer

### How to test?

1. Navigate to the user dashboard and verify that event cards with groups display correctly, even if a group has no slug
2. Check the group show page and confirm that events display properly with the correct organizer status
3. Verify that no errors occur when viewing events with unloaded user associations

### Why make this change?

These fixes prevent potential runtime errors that could occur when:
1. A group exists but has no slug value, which would cause rendering issues in the event card badges
2. The users association is not loaded when checking if a user is an organizer, which could lead to errors in the group show page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of group badges in event cards to only show the group link when a valid group slug is present.
  * Enhanced event organizer checks to prevent errors when user associations are not loaded, ensuring more reliable event display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->