### PR TITLE
another fix

### DIFF
--- a/lib/eventasaurus_web/live/auth_hooks.ex
+++ b/lib/eventasaurus_web/live/auth_hooks.ex
@@ -121,9 +121,12 @@ defmodule EventasaurusWeb.Live.AuthHooks do
               # For now, try to use the current token
               get_user_with_token(token)
               
-            {:error, _reason} ->
-              # Refresh failed, try with current token anyway
-              get_user_with_token(token)
+            {:error, reason} ->
+              # Refresh failed, token is likely expired or invalid
+              Logger.warning("Token refresh failed in LiveView: #{inspect(reason)}")
+              # Return nil to treat user as unauthenticated
+              # The next HTTP request will clear the session properly
+              nil
           end
         else
           # Token not near expiry or no refresh token

--- a/lib/eventasaurus_web/live/components/voting_interface_component.ex
+++ b/lib/eventasaurus_web/live/components/voting_interface_component.ex
@@ -704,6 +704,7 @@ defmodule EventasaurusWeb.VotingInterfaceComponent do
                   disabled={@loading}
                   class={star_class(@vote_state[option.id], star, @anonymous_mode) <> " p-1 sm:p-0 touch-target"}
                   aria-label={"Rate #{star} star#{if star > 1, do: "s"}"}
+                  aria-pressed={to_string(@vote_state[option.id] == star)}
                 >
                   <svg class="h-6 w-6 sm:h-5 sm:w-5" fill="currentColor" viewBox="0 0 20 20">
                     <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />


### PR DESCRIPTION
### TL;DR

Improved authentication error handling by properly clearing invalid sessions instead of attempting to use expired tokens.

### What changed?

- Modified `AuthHooks` to return `nil` when token refresh fails instead of trying to use the invalid token
- Updated `AuthPlug` to clear the session when token refresh fails instead of keeping stale tokens
- Added warning logs to better track authentication failures
- Added `aria-pressed` attribute to star rating buttons in the voting interface for improved accessibility

### How to test?

1. Test with an expired token to verify the session is properly cleared
2. Verify that failed token refreshes result in the user being logged out
3. Check browser console and server logs for appropriate warning messages
4. Test the voting interface with a screen reader to confirm the improved accessibility

### Why make this change?

Previously, when token refresh failed, the system would continue trying to use the invalid token, leading to repeated failed requests and a poor user experience. This change ensures that invalid sessions are properly cleared, forcing a new login when needed. The added logging helps with debugging authentication issues, and the accessibility improvement makes the voting interface more usable for people using assistive technologies.