### PR TITLE
last

### DIFF
--- a/lib/eventasaurus_web/components/event_components.ex
+++ b/lib/eventasaurus_web/components/event_components.ex
@@ -659,7 +659,7 @@ defmodule EventasaurusWeb.EventComponents do
               <.image_attribution external_image_data={@external_image_data} />
 
               <!-- Hidden fields for image data -->
-              <%= hidden_input f, :cover_image_url %>
+              <%= hidden_input f, :cover_image_url, value: Phoenix.HTML.Form.input_value(f, :cover_image_url) || @cover_image_url %>
               <%= if @external_image_data || Phoenix.HTML.Form.input_value(f, :external_image_data) do %>
                 <% encoded_data = case Phoenix.HTML.Form.input_value(f, :external_image_data) do
                   nil -> if is_map(@external_image_data), do: safe_json_encode(@external_image_data), else: ""


### PR DESCRIPTION
### TL;DR

Fixed an issue with cover image URL persistence in event forms.

### What changed?

Updated the hidden input field for `cover_image_url` to properly maintain its value when the form is reloaded or rerendered. The field now uses `Phoenix.HTML.Form.input_value(f, :cover_image_url)` as the primary value source, with a fallback to `@cover_image_url` if the form value is nil.

### How to test?

1. Start creating or editing an event
2. Upload or select a cover image
3. Submit the form with an error (e.g., leave a required field empty)
4. Verify that the cover image remains selected after the form reloads

### Why make this change?

Previously, when a form was resubmitted with errors, the cover image URL would be lost because the hidden input didn't maintain its value. This created a poor user experience where users had to reselect their cover image after fixing other form errors. This change ensures the cover image selection persists throughout the form submission process.