### PR TITLE
working migration

### DIFF
--- a/priv/repo/migrations/20250813170615_add_privacy_and_ordering_to_polls.exs
+++ b/priv/repo/migrations/20250813170615_add_privacy_and_ordering_to_polls.exs
@@ -1,27 +1,30 @@
 defmodule EventasaurusApp.Repo.Migrations.AddPrivacyAndOrderingToPolls do
   use Ecto.Migration
 
-  # Enable concurrent index creation to avoid long locks on large tables
-  @disable_ddl_transaction true
+  def up do
+    # Add privacy_settings column if it doesn't exist
+    execute """
+    ALTER TABLE polls 
+    ADD COLUMN IF NOT EXISTS privacy_settings jsonb DEFAULT '{}' NOT NULL
+    """
 
-  def change do
-    alter table(:polls) do
-      # Privacy settings as JSON field for flexibility
-      add :privacy_settings, :map, default: %{}, null: false
-      
-      # Order index for ordering multiple polls within an event
-      add :order_index, :integer, default: 0, null: false
-    end
+    # Add order_index column if it doesn't exist
+    execute """
+    ALTER TABLE polls 
+    ADD COLUMN IF NOT EXISTS order_index integer DEFAULT 0 NOT NULL
+    """
 
-    # Defensive drop to avoid duplicate indexes if one exists already
-    drop_if_exists index(:polls, [:event_id, :order_index])
+    # Create index if it doesn't exist
+    execute """
+    CREATE INDEX IF NOT EXISTS polls_event_id_order_index_active 
+    ON polls (event_id, order_index) 
+    WHERE deleted_at IS NULL
+    """
+  end
 
-    # Create partial index for efficient ordering queries (only non-deleted polls)
-    # This improves performance by excluding soft-deleted records from the index
-    # Use concurrently to reduce locking on large tables
-    create index(:polls, [:event_id, :order_index], 
-      where: "deleted_at IS NULL",
-      name: :polls_event_id_order_index_active,
-      concurrently: true)
+  def down do
+    execute "DROP INDEX IF EXISTS polls_event_id_order_index_active"
+    execute "ALTER TABLE polls DROP COLUMN IF EXISTS order_index"
+    execute "ALTER TABLE polls DROP COLUMN IF EXISTS privacy_settings"
   end
 end


### PR DESCRIPTION
### TL;DR

Refactored poll migration to use explicit `up/down` functions with SQL commands instead of `change/0` with Ecto DSL.

### What changed?

- Replaced `change/0` function with explicit `up/0` and `down/0` functions
- Changed from Ecto DSL to direct SQL execution with `execute` statements
- Added `IF NOT EXISTS` and `IF EXISTS` conditions to make migration more robust
- Changed `:map` type to `jsonb` for the `privacy_settings` column
- Removed `@disable_ddl_transaction true` directive
- Removed `concurrently: true` option from index creation

### How to test?

1. Run the migration to verify it adds the `privacy_settings` and `order_index` columns to the `polls` table
2. Verify the index `polls_event_id_order_index_active` is created correctly
3. Test rollback functionality to ensure columns and index are properly removed

### Why make this change?

This approach provides more control over the migration process by using explicit SQL commands. The `IF NOT EXISTS` and `IF EXISTS` conditions make the migration more resilient to being run multiple times or in environments where partial schema changes might already exist. The explicit `up/down` functions make the migration intent clearer and provide better rollback capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy settings to polls, giving organizers control over who can view or interact with a poll.
  * Introduced a stable display order for polls within events, ensuring a predictable, organized sequence.
  * Default settings are applied automatically to existing and new polls, requiring no user action.
  * Listing polls in events is now more responsive, improving browsing and management experiences for organizers and participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->