### PR TITLE
fixes again do it

### DIFF
--- a/lib/eventasaurus_web/live/components/date_selection_poll_component.ex
+++ b/lib/eventasaurus_web/live/components/date_selection_poll_component.ex
@@ -1355,15 +1355,16 @@ defmodule EventasaurusWeb.DateSelectionPollComponent do
 
   # Helper function to display suggester name with proper blank value handling
   defp display_suggester_name(suggested_by) when is_nil(suggested_by), do: "Anonymous"
+  defp display_suggester_name(%Ecto.Association.NotLoaded{}), do: "Anonymous"
   defp display_suggester_name(suggested_by) do
-    name = suggested_by.name
-    username = suggested_by.username
-    email = suggested_by.email
+    name = Map.get(suggested_by, :name)
+    username = Map.get(suggested_by, :username)
+    email = Map.get(suggested_by, :email)
     
     cond do
-      is_binary(name) and String.trim(name) != "" -> name
-      is_binary(username) and String.trim(username) != "" -> username
-      is_binary(email) and String.trim(email) != "" -> email
+      is_binary(name) and String.trim(name) != "" -> String.trim(name)
+      is_binary(username) and String.trim(username) != "" -> String.trim(username)
+      is_binary(email) and String.trim(email) != "" -> String.trim(email)
       true -> "Anonymous"
     end
   end

--- a/lib/eventasaurus_web/live/components/public_generic_poll_component.ex
+++ b/lib/eventasaurus_web/live/components/public_generic_poll_component.ex
@@ -637,15 +637,16 @@ defmodule EventasaurusWeb.PublicGenericPollComponent do
 
   # Helper function to display suggester name with proper blank value handling
   defp display_suggester_name(suggested_by) when is_nil(suggested_by), do: "Anonymous"
+  defp display_suggester_name(%Ecto.Association.NotLoaded{}), do: "Anonymous"
   defp display_suggester_name(suggested_by) do
-    name = suggested_by.name
-    username = suggested_by.username
-    email = suggested_by.email
+    name = Map.get(suggested_by, :name)
+    username = Map.get(suggested_by, :username)
+    email = Map.get(suggested_by, :email)
     
     cond do
-      is_binary(name) and String.trim(name) != "" -> name
-      is_binary(username) and String.trim(username) != "" -> username
-      is_binary(email) and String.trim(email) != "" -> email
+      is_binary(name) and String.trim(name) != "" -> String.trim(name)
+      is_binary(username) and String.trim(username) != "" -> String.trim(username)
+      is_binary(email) and String.trim(email) != "" -> String.trim(email)
       true -> "Anonymous"
     end
   end

--- a/lib/eventasaurus_web/live/components/public_movie_poll_component.ex
+++ b/lib/eventasaurus_web/live/components/public_movie_poll_component.ex
@@ -530,15 +530,16 @@ defmodule EventasaurusWeb.PublicMoviePollComponent do
 
   # Helper function to display suggester name with proper blank value handling
   defp display_suggester_name(suggested_by) when is_nil(suggested_by), do: "Anonymous"
+  defp display_suggester_name(%Ecto.Association.NotLoaded{}), do: "Anonymous"
   defp display_suggester_name(suggested_by) do
-    name = suggested_by.name
-    username = suggested_by.username
-    email = suggested_by.email
+    name = Map.get(suggested_by, :name)
+    username = Map.get(suggested_by, :username)
+    email = Map.get(suggested_by, :email)
     
     cond do
-      is_binary(name) and String.trim(name) != "" -> name
-      is_binary(username) and String.trim(username) != "" -> username
-      is_binary(email) and String.trim(email) != "" -> email
+      is_binary(name) and String.trim(name) != "" -> String.trim(name)
+      is_binary(username) and String.trim(username) != "" -> String.trim(username)
+      is_binary(email) and String.trim(email) != "" -> String.trim(email)
       true -> "Anonymous"
     end
   end

--- a/lib/eventasaurus_web/live/event_live/form_helpers.ex
+++ b/lib/eventasaurus_web/live/event_live/form_helpers.ex
@@ -151,12 +151,17 @@ defmodule EventasaurusWeb.EventLive.FormHelpers do
     participation_type = Map.get(params, "participation_type", "free")
     
     # Apply mappings in sequence, each building on the previous
-    base_attrs
+    attrs = base_attrs
     |> map_date_certainty_to_status(date_certainty)
     |> map_venue_certainty_to_fields(venue_certainty)
     |> map_participation_type_to_fields(participation_type)
     |> resolve_status_conflicts(date_certainty, venue_certainty, participation_type)
     |> set_defaults()
+    
+    # Convert all atom keys to strings to avoid mixed keys error in changeset
+    attrs
+    |> Enum.map(fn {k, v} -> {to_string(k), v} end)
+    |> Enum.into(%{})
   end
 
   # Private helper to resolve conflicts when multiple factors affect status


### PR DESCRIPTION
### TL;DR

Fix suggester name display and resolve mixed key errors in event form processing.

### What changed?

- Added handling for `%Ecto.Association.NotLoaded{}` in `display_suggester_name` function across multiple components
- Replaced direct struct access with safer `Map.get/3` to prevent errors when accessing user fields
- Added `String.trim/1` to name, username, and email values to ensure consistent display
- Fixed mixed key issue in form processing by converting all atom keys to strings in the event attributes map

### How to test?

1. Test viewing polls with suggested options where the suggester data might not be fully loaded
2. Verify that suggester names display correctly in all poll types (date selection, generic, movie)
3. Create and edit events to ensure the form processing works without errors
4. Check that anonymous suggestions display properly

### Why make this change?

These changes improve error handling and prevent crashes when dealing with user data that might be partially loaded or in an unexpected format. The fix for mixed keys in the event form prevents potential errors during changeset creation, while the improved suggester name handling ensures consistent display of user information across all poll types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevented crashes by safely handling missing/ unloaded suggester info and defaulting to “Anonymous.”
  - Cleaned up displayed names by trimming whitespace and using the first available non-blank name, username, or email.
  - Improved consistency of “Anonymous” fallback when suggester details are absent.
  - Increased form stability by normalizing event attribute keys, reducing edge-case errors during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->