### PR TITLE
more fixes small small

### DIFF
--- a/lib/eventasaurus_web/live/event_live/form_helpers.ex
+++ b/lib/eventasaurus_web/live/event_live/form_helpers.ex
@@ -61,7 +61,7 @@ defmodule EventasaurusWeb.EventLive.FormHelpers do
 
   def map_venue_certainty_to_fields(base_attrs, "polling") do
     # Create location poll - if not already polling for date, set status to polling
-    current_status = Map.get(base_attrs, "status", "confirmed")
+    current_status = Map.get(base_attrs, "status") || Map.get(base_attrs, :status) || "confirmed"
     if to_string(current_status) != "polling" do
       Map.put(base_attrs, "status", "polling")
     else


### PR DESCRIPTION
### TL;DR

Fixed event validation handling and improved error logging for better debugging.

### What changed?

- Fixed a bug in `map_venue_certainty_to_fields` function to properly handle status values that could be either string keys or atom keys
- Enhanced error logging in the event validation process:
  - Replaced basic error inspection with `Ecto.Changeset.traverse_errors` to generate more readable error messages
  - Implemented proper error sanitization to avoid logging sensitive data while still providing useful error context

### How to test?

1. Create a new event with polling for location
2. Verify that the status is correctly set regardless of whether the status was previously a string or atom key
3. Intentionally create an invalid event and check server logs to confirm the improved error format is displayed

### Why make this change?

The previous implementation had two issues:
1. It didn't properly handle status values that could be stored with either string or atom keys, causing potential bugs when determining event status
2. The error logging was basic and potentially exposed raw field values, which could include sensitive information. The new implementation provides more readable error messages while properly sanitizing the data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected venue status handling during “polling” to reliably detect current status across formats and default sensibly, preventing unintended status changes.

* **Chores**
  * Improved validation error logging to use sanitized, human-readable messages for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->