### PR TITLE
small fixes

### DIFF
--- a/lib/eventasaurus_web/live/events_live.ex
+++ b/lib/eventasaurus_web/live/events_live.ex
@@ -93,14 +93,15 @@ defmodule EventasaurusWeb.EventsLive do
           <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
             <%= for event <- @events do %>
               <a
-                href={"/" <> event.slug}
+                href={~p"/#{event.slug}"}
                 class="group relative bg-white rounded-lg shadow-sm hover:shadow-lg transition-shadow duration-200 overflow-hidden"
               >
                 <%!-- Event Image --%>
                 <div class="aspect-w-16 aspect-h-9 bg-gray-200">
-                  <%= if event.cover_image_url || event.external_image_data do %>
+                  <% image_url = event.cover_image_url || get_external_image_url(event.external_image_data) %>
+                  <%= if image_url do %>
                     <img
-                      src={event.cover_image_url || get_external_image_url(event.external_image_data)}
+                      src={image_url}
                       alt={event.title}
                       class="object-cover w-full h-48"
                     />


### PR DESCRIPTION
### TL;DR

Improved event filtering to exclude canceled events and enhanced image handling in the events list view.

### What changed?

- Added filtering to exclude canceled events from public event listings
- Modified the event query to use the `apply_soft_delete_filter` helper function
- Updated event filtering logic to consider both end dates and event status
- Refactored the event card image handling in the events list view
- Updated link generation to use the `~p` sigil for path generation

### How to test?

1. Create events with different statuses (active, canceled)
2. Verify that canceled events don't appear in the public events listing
3. Check that events with end dates in the past are properly filtered out when not including ended events
4. Confirm that event images display correctly in the events list view
5. Verify that event links work properly with the updated path generation

### Why make this change?

This change improves the user experience by ensuring canceled events don't appear in public listings. It also enhances code maintainability by using the existing soft delete filter helper and optimizing the image handling logic to reduce redundancy and improve readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Public event listings now consistently hide canceled events unless explicitly included.
  - Soft-deleted events are excluded by default, with an option to include them when needed.
  - Event cards no longer show broken images; a placeholder appears if no valid image URL is available.
  - Links to event pages are more reliable and router-aware.

- Refactor
  - Centralized soft-delete filtering.
  - Streamlined image URL handling in event cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->