### PR TITLE
Change default event dates to 5 days in future

### DIFF
--- a/lib/eventasaurus_web/live/event_live/new.ex
+++ b/lib/eventasaurus_web/live/event_live/new.ex
@@ -26,7 +26,7 @@ defmodule EventasaurusWeb.EventLive.New do
     case ensure_user_struct(socket.assigns.auth_user) do
       {:ok, user} ->
         changeset = Events.change_event(%Event{})
-        today = Date.utc_today() |> Date.to_iso8601()
+        default_date = Date.utc_today() |> Date.add(5) |> Date.to_iso8601()
         venues = Venues.list_venues()
         # Load groups that the user is a member of or created
         user_groups = Groups.list_user_groups(user)
@@ -60,8 +60,8 @@ defmodule EventasaurusWeb.EventLive.New do
 
         # Update form_data with the random image and smart defaults
         initial_form_data = %{
-          "start_date" => today,
-          "ends_date" => today,
+          "start_date" => default_date,
+          "ends_date" => default_date,
           # Legacy date polling field removed
           "slug" => Nanoid.generate(10),
           "taxation_type" => default_taxation_type,


### PR DESCRIPTION
## Summary
- Changes default event start and end dates from today to 5 days in the future
- Provides a more reasonable starting point for event creation since most events are planned in advance
- Maintains backward compatibility for all existing functionality

## Changes Made
- Updated `default_date` calculation in `lib/eventasaurus_web/live/event_live/new.ex:29` to add 5 days to current date
- Updated form initialization to use `default_date` instead of `today` for both start_date and ends_date

## Test Results
- ✅ Code compiles successfully
- ✅ Phoenix server starts without errors
- ✅ Date calculation verified: August 20, 2025 → August 25, 2025
- ✅ No breaking changes to existing event creation flow

## Issue
Closes #732

🤖 Generated with [Claude Code](https://claude.ai/code)