### PR TITLE
last one

### DIFF
--- a/priv/repo/migrations/20250830101647_update_poll_options_unique_constraint_for_places.exs
+++ b/priv/repo/migrations/20250830101647_update_poll_options_unique_constraint_for_places.exs
@@ -14,7 +14,7 @@ defmodule EventasaurusApp.Repo.Migrations.UpdatePollOptionsUniqueConstraintForPl
     execute """
     CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS poll_options_unique_place_per_poll
     ON poll_options (poll_id, (external_data->>'place_id'))
-    WHERE (external_data->>'place_id') IS NOT NULL
+    WHERE nullif(external_data->>'place_id', '') IS NOT NULL
       AND status = 'active'
       AND deleted_at IS NULL
     """


### PR DESCRIPTION
### TL;DR

Fix duplicate poll options detection logic to properly handle empty place IDs and respect user-specific options.

### What changed?

- Updated the duplicate poll option detection logic to:
    - Properly validate place IDs by checking if they're non-empty strings
    - Add `deleted_at` check to ensure we don't consider deleted options
    - For non-place options, restrict duplicate checking to options created by the same user
- Modified the unique index in the migration to use `nullif` to properly handle empty place ID strings

### How to test?

1. Try adding a poll option with an empty place ID string
2. Verify that different users can add options with the same title
3. Confirm that the same user cannot add duplicate options with the same title
4. Test that place-based options are still globally unique across all users

### Why make this change?

The previous implementation had two issues:

1. It didn't properly handle empty place ID strings, treating them as valid place IDs
2. For non-place options, it prevented any user from adding an option with the same title, even though these should be user-specific

This change ensures that place-based options remain globally unique while allowing different users to suggest options with the same title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - More accurate duplicate detection for place-based options by treating empty place IDs as absent.
  - Excludes soft-deleted options from duplicate checks.
  - Restricts non-place duplicates to suggestions by the same user, reducing cross-user false positives.
  - Considers only active options when checking duplicates.
- Chores
  - Updated database index to align with non-empty place ID handling and soft-delete/active filters.
  - Improved input validation with clearer errors for invalid poll or user IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->