### PR TITLE
changes to seeding

### DIFF
--- a/priv/repo/dev_seeds/events.exs
+++ b/priv/repo/dev_seeds/events.exs
@@ -7,7 +7,8 @@ defmodule DevSeeds.Events do
   import EventasaurusApp.Factory
   alias DevSeeds.Helpers
   alias EventasaurusApp.Repo
-  alias EventasaurusApp.Events.{Event, EventUser, EventParticipant}
+  alias EventasaurusApp.Events.EventUser
+  alias EventasaurusWeb.Services.DefaultImagesService
   
   @doc """
   Seeds events with various states and configurations.
@@ -189,8 +190,11 @@ defmodule DevSeeds.Events do
       %{venue: build(:realistic_venue)}
     end
     
-    # Create the event
-    event = insert(:realistic_event, Map.merge(attrs, venue_attrs))
+    # Get a random default image for the event
+    image_attrs = get_random_image_attrs()
+    
+    # Create the event with image
+    event = insert(:realistic_event, Map.merge(attrs, Map.merge(venue_attrs, image_attrs)))
     
     # Assign to group if selected
     if group do
@@ -346,5 +350,18 @@ defmodule DevSeeds.Events do
       
       event
     end)
+  end
+  
+  defp get_random_image_attrs do
+    # Get a random default image from our collection
+    case DefaultImagesService.get_random_image() do
+      nil ->
+        # Fallback if no images are available
+        %{}
+      
+      image ->
+        # Use the image URL as cover_image_url
+        %{cover_image_url: image.url}
+    end
   end
 end

--- a/priv/repo/dev_seeds/groups.exs
+++ b/priv/repo/dev_seeds/groups.exs
@@ -7,7 +7,6 @@ defmodule DevSeeds.Groups do
   import EventasaurusApp.Factory
   alias DevSeeds.Helpers
   alias EventasaurusApp.Repo
-  alias EventasaurusApp.Groups.{Group, GroupUser}
   
   defp slugify(name) do
     name

--- a/priv/repo/dev_seeds/helpers.exs
+++ b/priv/repo/dev_seeds/helpers.exs
@@ -4,9 +4,7 @@ defmodule DevSeeds.Helpers do
   """
 
   import EventasaurusApp.Factory
-  alias EventasaurusApp.Repo
   alias EventasaurusApp.Auth.{Client, ServiceRoleHelper, SeedUserManager}
-  alias EventasaurusApp.Accounts
   
   @doc """
   Print a colorful status message

--- a/priv/repo/dev_seeds/runner.exs
+++ b/priv/repo/dev_seeds/runner.exs
@@ -45,11 +45,13 @@ if config.clean_first do
   Repo.delete_all(EventasaurusApp.Events.EventParticipant)
   Repo.delete_all(EventasaurusApp.Events.EventUser)
   Repo.delete_all(EventasaurusApp.Groups.GroupUser)
-  Repo.delete_all(EventasaurusApp.Groups.Group)
   Repo.delete_all(EventasaurusApp.Events.Order)  # Clean orders before events
   Repo.delete_all(EventasaurusApp.Events.Ticket) # Clean tickets before events
   Repo.delete_all(EventasaurusApp.Events.Event)
   Repo.delete_all(EventasaurusApp.Venues.Venue)
+  # Delete groups before users (groups reference users via created_by_id)
+  # Force delete all groups including soft-deleted ones
+  Repo.query!("DELETE FROM groups")
   # Delete all users (we'll recreate test users)
   Repo.delete_all(EventasaurusApp.Accounts.User)
   


### PR DESCRIPTION
### TL;DR

Improved seed data generation and fixed auth user handling for development environment.

### What changed?

- Enhanced error handling in `SeedUserManager` to better handle existing auth users
- Updated Logger calls from `warn` to `warning` for consistency
- Added special handling for the "[holden@gmail.com](mailto:holden@gmail.com)" user with a known Supabase ID
- Removed the unused `fetch_supabase_user_by_email` function
- Added random cover images to seeded events using `DefaultImagesService`
- Improved database cleanup in the seed runner to properly handle dependencies
- Fixed group deletion by using a direct SQL query to force delete all groups

### How to test?

1. Run the seed script with `mix run priv/repo/dev_seeds/runner.exs`
2. Verify that users are created properly, including handling of existing auth users
3. Check that seeded events have cover images
4. Confirm that the database is properly cleaned when using the `clean_first` option

### Why make this change?

These improvements make the development environment more robust by:

1. Properly handling edge cases when seeding users that already exist in Supabase
2. Making seeded events more visually appealing with cover images
3. Ensuring clean database resets during development
4. Fixing issues with dependency relationships during database cleanup