### PR TITLE
final fixes

### DIFF
--- a/lib/eventasaurus_app/events.ex
+++ b/lib/eventasaurus_app/events.ex
@@ -1469,7 +1469,7 @@ defmodule EventasaurusApp.Events do
           
           # Role-based counts (all active events)
           created: fragment("COUNT(CASE WHEN ? IS NOT NULL THEN 1 END)", eu.id),
-          participating: fragment("COUNT(CASE WHEN ? IS NOT NULL THEN 1 END)", ep.id)
+          participating: fragment("COUNT(CASE WHEN ? IS NOT NULL AND ? IS NULL THEN 1 END)", ep.id, eu.id)
         }
     )
 

--- a/lib/eventasaurus_app/performance_benchmark.ex
+++ b/lib/eventasaurus_app/performance_benchmark.ex
@@ -85,15 +85,6 @@ defmodule EventasaurusApp.PerformanceBenchmark do
     }
   end
   
-  defp count_events_by_filter(user, time_filter, ownership_filter) do
-    Events.list_unified_events_for_user_optimized(user, [
-      time_filter: time_filter,
-      ownership_filter: ownership_filter,
-      limit: 1000
-    ])
-    |> length()
-  end
-  
   defp calculate_averages(results) do
     count = length(results)
     

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -61,9 +61,12 @@ defmodule EventasaurusWeb.FeatureCase do
     end
 
     # Start a Wallaby session for browser tests
-    metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(EventasaurusApp.Repo, self())
-    {:ok, session} = Wallaby.start_session(metadata: metadata)
-
-    %{session: session}
+    if Mix.env() == :test and Code.ensure_loaded?(Wallaby) do
+      metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(EventasaurusApp.Repo, self())
+      {:ok, session} = apply(Wallaby, :start_session, [[metadata: metadata]])
+      %{session: session}
+    else
+      %{session: nil}
+    end
   end
 end


### PR DESCRIPTION
### TL;DR

Fixed dashboard event counting logic to prevent double-counting events where a user is both organizer and participant.

### What changed?

- Modified the SQL query in `Events.ex` to exclude events from the "participating" count when the user is also an organizer
- Removed redundant event counting functions from `dashboard_live.ex` and `performance_benchmark.ex`
- Replaced client-side filter count calculation with a direct database query for more accurate counts
- Updated the dev seed script to exclude deleted events when checking for existing organizer events
- Added safeguards to prevent title duplication and unbounded recursion in the seed script
- Made the feature test case more resilient by adding conditional Wallaby session initialization

### How to test?

1. Log in as a user who is both an organizer and participant for some events
2. Navigate to the dashboard and verify the "Created" and "Participating" counts are correct (events should only appear in one category)
3. Switch between different dashboard filters to ensure counts remain accurate
4. Run the dev seed script to verify it correctly handles existing events

### Why make this change?

The previous implementation was double-counting events where a user had multiple roles (e.g., both organizer and participant). This led to inflated counts in the dashboard filters and potentially confusing UX. The change ensures each event is counted only once in the appropriate category, providing users with accurate information about their event participation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tickets now use secure, compact IDs (EVT-<order.id>-<hash>).
- Bug Fixes
  - “Participating” count on the dashboard now excludes organizers for accurate totals.
  - Dev seeding and existence checks ignore deleted events to prevent duplicates.
- Refactor
  - Dashboard counts centralized to a single query source for consistency and reliability.
- Chores
  - Performance benchmarking updated to use the centralized count source.
- Tests
  - Conditional browser session startup prevents failures when UI testing tools aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->