### PR TITLE
last last

### DIFF
--- a/priv/repo/dev_seeds/ensure_key_organizers.exs
+++ b/priv/repo/dev_seeds/ensure_key_organizers.exs
@@ -34,7 +34,8 @@ defmodule DevSeeds.EnsureKeyOrganizers do
         from(eu in EventUser, 
           join: e in assoc(eu, :event),
           where: eu.user_id == ^movie_user.id and eu.role in ["owner", "organizer"] and is_nil(e.deleted_at)),
-        :count
+        :count,
+        :id
       )
       
       if existing_count < 5 do
@@ -92,7 +93,8 @@ defmodule DevSeeds.EnsureKeyOrganizers do
         from(eu in EventUser, 
           join: e in assoc(eu, :event),
           where: eu.user_id == ^foodie_user.id and eu.role in ["owner", "organizer"] and is_nil(e.deleted_at)),
-        :count
+        :count,
+        :id
       )
       
       if existing_count < 5 do


### PR DESCRIPTION
### TL;DR

Added `:id` parameter to the `Repo.aggregate` calls in the dev seeds script.

### What changed?

Modified the `Repo.aggregate` calls in `ensure_key_organizers.exs` to include `:id` as a second parameter alongside `:count`. This change affects both the movie user and foodie user sections of the script.

### How to test?

1. Run the dev seeds script
2. Verify that the key organizers are created correctly
3. Check that no errors occur during the aggregation queries

### Why make this change?

The `:id` parameter is required for proper functioning of the `Repo.aggregate` function when using it with `:count`. Without this parameter, the count operation might not work as expected, potentially causing issues with the seeding process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development seed reliability by explicitly counting records by ID when determining whether to create sample events, reducing potential miscounts during local setup.
  * This change applies only to developer environments and does not alter production functionality or user workflows.
  * No user-facing behavior changes; the application continues to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->