### PR TITLE
bad bug

### DIFF
--- a/lib/eventasaurus_web/live/auth_hooks.ex
+++ b/lib/eventasaurus_web/live/auth_hooks.ex
@@ -33,6 +33,9 @@ defmodule EventasaurusWeb.Live.AuthHooks do
 
   require Logger
 
+  # Compile-time check for dev mode that works in production
+  defp dev_mode?, do: Application.get_env(:eventasaurus, :environment) == :dev
+
   @doc """
   Handles different authentication mount hooks.
 
@@ -107,7 +110,7 @@ defmodule EventasaurusWeb.Live.AuthHooks do
   defp assign_auth_user(socket, session) do
     assign_new(socket, :auth_user, fn ->
       # Check for dev mode login FIRST (dev only)
-      if Mix.env() == :dev && session["dev_mode_login"] == true && session["current_user_id"] do
+      if dev_mode?() && session["dev_mode_login"] == true && session["current_user_id"] do
         # Dev mode: directly load the user from database
         user_id = session["current_user_id"]
         case EventasaurusApp.Repo.get(EventasaurusApp.Accounts.User, user_id) do

--- a/priv/repo/dev_seeds/ensure_key_organizers.exs
+++ b/priv/repo/dev_seeds/ensure_key_organizers.exs
@@ -34,8 +34,7 @@ defmodule DevSeeds.EnsureKeyOrganizers do
         from(eu in EventUser, 
           join: e in assoc(eu, :event),
           where: eu.user_id == ^movie_user.id and eu.role in ["owner", "organizer"] and is_nil(e.deleted_at)),
-        :count,
-        :id
+        :count
       )
       
       if existing_count < 5 do
@@ -93,8 +92,7 @@ defmodule DevSeeds.EnsureKeyOrganizers do
         from(eu in EventUser, 
           join: e in assoc(eu, :event),
           where: eu.user_id == ^foodie_user.id and eu.role in ["owner", "organizer"] and is_nil(e.deleted_at)),
-        :count,
-        :id
+        :count
       )
       
       if existing_count < 5 do


### PR DESCRIPTION
### TL;DR

Fixed dev mode authentication check to work properly in production and simplified database count queries.

### What changed?

- Added a `dev_mode?/0` helper function that checks the application environment instead of using `Mix.env()` directly
- Updated the authentication logic to use this new helper function
- Removed unnecessary `:id` parameter from two `Repo.aggregate` count queries in the dev seeds script

### How to test?

1. Verify that dev mode login still works in development environment
2. Confirm that the application starts properly in production without Mix dependency errors
3. Run the dev seeds script to ensure it still creates the expected organizer records

### Why make this change?

Using `Mix.env()` in production code can cause runtime errors since Mix is not available in compiled releases. This change ensures the dev mode check works reliably in all environments by using application configuration instead. Additionally, the database count queries were simplified by removing an unnecessary parameter.