### PR TITLE
movie urls

### DIFF
--- a/lib/eventasaurus_web/live/components/public_movie_poll_component.ex
+++ b/lib/eventasaurus_web/live/components/public_movie_poll_component.ex
@@ -349,7 +349,16 @@ defmodule EventasaurusWeb.PublicMoviePollComponent do
                       <% end %>
 
                       <div class="flex-1 min-w-0">
-                        <h4 class="font-medium text-gray-900 mb-1"><%= option.title %></h4>
+                        <% movie_url = MovieUtils.get_primary_movie_url(option) %>
+                        <%= if movie_url do %>
+                          <h4 class="font-medium text-gray-900 mb-1">
+                            <.link href={movie_url} target="_blank" class="text-blue-600 hover:text-blue-800 hover:underline">
+                              <%= option.title %>
+                            </.link>
+                          </h4>
+                        <% else %>
+                          <h4 class="font-medium text-gray-900 mb-1"><%= option.title %></h4>
+                        <% end %>
 
                         <%= if option.description do %>
                           <p class="text-sm text-gray-600 mb-2"><%= truncate(option.description, length: 80, separator: " ") %></p>

--- a/lib/eventasaurus_web/live/components/voting_interface_component.ex
+++ b/lib/eventasaurus_web/live/components/voting_interface_component.ex
@@ -312,7 +312,16 @@ defmodule EventasaurusWeb.VotingInterfaceComponent do
           
           <div class="flex-1 min-w-0">
             <div class="flex items-center space-x-2">
-              <h4 class={"text-sm font-medium text-gray-900 " <> if(@poll.poll_type == "movie", do: "line-clamp-1 sm:line-clamp-none", else: "break-words")}><%= option.title %></h4>
+              <% movie_url = if @poll.poll_type == "movie", do: MovieUtils.get_primary_movie_url(option), else: nil %>
+              <%= if movie_url do %>
+                <h4 class={"text-sm font-medium " <> if(@poll.poll_type == "movie", do: "line-clamp-1 sm:line-clamp-none", else: "break-words")}>
+                  <.link href={movie_url} target="_blank" class="text-blue-600 hover:text-blue-800 hover:underline">
+                    <%= option.title %>
+                  </.link>
+                </h4>
+              <% else %>
+                <h4 class={"text-sm font-medium text-gray-900 " <> if(@poll.poll_type == "movie", do: "line-clamp-1 sm:line-clamp-none", else: "break-words")}><%= option.title %></h4>
+              <% end %>
               <%= if has_time_slots?(option) do %>
                 <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
                   <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -488,7 +497,16 @@ defmodule EventasaurusWeb.VotingInterfaceComponent do
           
           <div class="flex-1 min-w-0">
             <div class="flex items-start sm:items-center space-x-2">
-              <h4 class={"text-sm font-medium text-gray-900 " <> if(@poll.poll_type == "movie", do: "line-clamp-1 sm:line-clamp-none", else: "break-words")}><%= option.title %></h4>
+              <% movie_url = if @poll.poll_type == "movie", do: MovieUtils.get_primary_movie_url(option), else: nil %>
+              <%= if movie_url do %>
+                <h4 class={"text-sm font-medium " <> if(@poll.poll_type == "movie", do: "line-clamp-1 sm:line-clamp-none", else: "break-words")}>
+                  <.link href={movie_url} target="_blank" class="text-blue-600 hover:text-blue-800 hover:underline">
+                    <%= option.title %>
+                  </.link>
+                </h4>
+              <% else %>
+                <h4 class={"text-sm font-medium text-gray-900 " <> if(@poll.poll_type == "movie", do: "line-clamp-1 sm:line-clamp-none", else: "break-words")}><%= option.title %></h4>
+              <% end %>
               <%= if has_time_slots?(option) do %>
                 <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
                   <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -636,7 +654,16 @@ defmodule EventasaurusWeb.VotingInterfaceComponent do
               <% end %>
               
               <div class="flex-1 min-w-0">
-                <h4 class="text-sm font-medium text-gray-900 line-clamp-1 sm:line-clamp-none"><%= option.title %></h4>
+                <% movie_url = if @poll.poll_type == "movie", do: MovieUtils.get_primary_movie_url(option), else: nil %>
+                <%= if movie_url do %>
+                  <h4 class="text-sm font-medium line-clamp-1 sm:line-clamp-none">
+                    <.link href={movie_url} target="_blank" class="text-blue-600 hover:text-blue-800 hover:underline">
+                      <%= option.title %>
+                    </.link>
+                  </h4>
+                <% else %>
+                  <h4 class="text-sm font-medium text-gray-900 line-clamp-1 sm:line-clamp-none"><%= option.title %></h4>
+                <% end %>
                 <%= if option.description do %>
                   <p class={"text-xs text-gray-500 mt-0.5 sm:mt-1 " <> if(@poll.poll_type == "movie", do: "line-clamp-2", else: "")}><%= if @poll.poll_type == "movie", do: truncate(option.description, length: 240, separator: " "), else: option.description %></p>
                 <% end %>
@@ -750,7 +777,16 @@ defmodule EventasaurusWeb.VotingInterfaceComponent do
                   <% end %>
                   
                   <div class="flex-1 min-w-0">
-                    <h5 class="text-sm font-medium text-gray-900 line-clamp-1 sm:line-clamp-none"><%= option.title %></h5>
+                    <% movie_url = if @poll.poll_type == "movie", do: MovieUtils.get_primary_movie_url(option), else: nil %>
+                    <%= if movie_url do %>
+                      <h5 class="text-sm font-medium line-clamp-1 sm:line-clamp-none">
+                        <.link href={movie_url} target="_blank" class="text-blue-600 hover:text-blue-800 hover:underline">
+                          <%= option.title %>
+                        </.link>
+                      </h5>
+                    <% else %>
+                      <h5 class="text-sm font-medium text-gray-900 line-clamp-1 sm:line-clamp-none"><%= option.title %></h5>
+                    <% end %>
                     <%= if option.description do %>
                       <p class={"text-xs text-gray-500 mt-0.5 " <> if(@poll.poll_type == "movie", do: "line-clamp-1 sm:line-clamp-2", else: "mt-1")}><%= if @poll.poll_type == "movie", do: truncate(option.description, length: 240, separator: " "), else: option.description %></p>
                     <% end %>
@@ -829,7 +865,16 @@ defmodule EventasaurusWeb.VotingInterfaceComponent do
       <div class="px-4 sm:px-6 py-4">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div class="flex-1 min-w-0">
-            <h4 class="text-sm font-medium text-gray-900"><%= option.title %></h4>
+            <% movie_url = if @poll.poll_type == "movie", do: MovieUtils.get_primary_movie_url(option), else: nil %>
+            <%= if movie_url do %>
+              <h4 class="text-sm font-medium">
+                <.link href={movie_url} target="_blank" class="text-blue-600 hover:text-blue-800 hover:underline">
+                  <%= option.title %>
+                </.link>
+              </h4>
+            <% else %>
+              <h4 class="text-sm font-medium text-gray-900"><%= option.title %></h4>
+            <% end %>
             <%= if option.description do %>
               <p class="text-sm text-gray-500 mt-1"><%= if @poll.poll_type == "movie", do: truncate(option.description, length: 240, separator: " "), else: option.description %></p>
             <% end %>


### PR DESCRIPTION
### TL;DR

Added clickable movie links in poll options that direct users to TMDB or IMDb.

### What changed?

- Added new utility functions in `MovieUtils` to extract and retrieve movie URLs from poll option data:
  - `get_movie_urls/1` - Extracts TMDB and IMDb URLs from movie data
  - `get_primary_movie_url/1` - Returns the primary URL (preferring TMDB over IMDb)
- Modified movie title displays in multiple components to render as clickable links when a URL is available:
  - Updated `PublicMoviePollComponent` to show clickable movie titles
  - Updated `VotingInterfaceComponent` to show clickable movie titles in various voting views
- All links open in a new tab and have appropriate hover styling

### How to test?

1. Create a movie poll with movies that have TMDB or IMDb data
2. View the poll in different interfaces (public view, voting interface)
3. Verify that movie titles appear as blue, clickable links
4. Click on a movie title and confirm it opens the correct TMDB/IMDb page in a new tab
5. Test with movies that don't have external URLs to ensure they still display properly as non-clickable text

### Why make this change?

This enhancement improves the user experience by providing direct access to detailed movie information on TMDB or IMDb. Users can now easily research movies while deciding their votes without having to search for the movies separately, making the voting process more informed and convenient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Movie poll option titles now become clickable links to their primary movie page (e.g., TMDB/IMDB) when available, opening in a new tab. Applies across all voting modes and public/list-building views. Titles without a URL remain plain text. No changes to voting behavior.
* Style
  * Linked movie titles use blue link styling with hover effects while preserving existing truncation and wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->