### PR TITLE
another

### DIFF
--- a/lib/eventasaurus_web/live/components/poll_creation_component.ex
+++ b/lib/eventasaurus_web/live/components/poll_creation_component.ex
@@ -444,7 +444,7 @@ defmodule EventasaurusWeb.PollCreationComponent do
                               <%= for option <- Poll.max_rankings_options() do %>
                                 <option
                                   value={option}
-                                  selected={get_max_rankings_setting(@changeset, @poll) == option}
+                                  selected={get_max_rankings_setting(@changeset, @poll) == to_string(option)}
                                 >
                                   <%= Poll.max_rankings_display(option) %>
                                 </option>
@@ -849,17 +849,17 @@ defmodule EventasaurusWeb.PollCreationComponent do
   defp get_max_rankings_setting(changeset, poll) do
     settings = Ecto.Changeset.get_field(changeset, :settings) || %{}
     case Map.get(settings, "max_rankings") do
-      v when is_integer(v) -> v
+      v when is_integer(v) -> Integer.to_string(v)
       v when is_binary(v) ->
         case Integer.parse(v) do
-          {int, ""} when int in [3, 5, 7] -> int
+          {int, ""} when int in [3, 5, 7] -> Integer.to_string(int)
           _ -> fallback_max_rankings(poll)
         end
       _ -> fallback_max_rankings(poll)
     end
   end
 
-  defp fallback_max_rankings(nil), do: 3
-  defp fallback_max_rankings(poll), do: Poll.get_max_rankings(poll)
+  defp fallback_max_rankings(nil), do: "3"
+  defp fallback_max_rankings(poll), do: Poll.get_max_rankings(poll) |> to_string()
 
 end


### PR DESCRIPTION
### TL;DR

Fixed a type mismatch in poll max rankings selection by consistently using strings for comparison.

### What changed?

Modified the `get_max_rankings_setting` function to consistently return string values instead of integers. Updated the `fallback_max_rankings` function to also return string values. This ensures that when comparing the selected option value with the current setting, we're comparing strings to strings rather than strings to integers.

### How to test?

1. Navigate to poll creation
2. Select different max ranking options (3, 5, or 7)
3. Verify that the correct option is selected in the dropdown
4. Save the poll and reopen to confirm the selection persists

### Why make this change?

The bug occurred because HTML option values are always strings, but our code was comparing them with integer values. This caused the `selected` attribute to incorrectly evaluate to false even when an option should have been selected. By consistently using string values throughout the comparison process, we ensure the dropdown correctly reflects the current setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the “Max rankings” dropdown in poll creation consistently shows the correct selected value.
  * Standardized the default “Max rankings” to 3 for more predictable behavior.
  * Resolved issues where the selection might not appear highlighted or could revert due to inconsistent value handling.

* **Refactor**
  * Internal normalization of “Max rankings” values to improve UI consistency without changing any public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->