### PR TITLE
group bugs

### DIFF
--- a/lib/eventasaurus_web/live/group_live/index.ex
+++ b/lib/eventasaurus_web/live/group_live/index.ex
@@ -38,8 +38,28 @@ defmodule EventasaurusWeb.GroupLive.Index do
   end
 
   @impl true
-  def handle_event("filter_my_groups", %{"show_my_groups_only" => show_my_groups}, socket) do
-    show_my_groups_only = show_my_groups == "true"
+  def handle_event("search", params, socket) do
+    # Handle different parameter formats for search clearing
+    query = case params do
+      %{"search[query]" => query} -> query
+      %{"search" => %{"query" => query}} -> query
+      _ -> ""
+    end
+    
+    {:noreply,
+     socket
+     |> assign(:search_query, query)
+     |> load_groups()}
+  end
+
+  @impl true
+  def handle_event("filter_my_groups", params, socket) do
+    # Handle checkbox state - when unchecked, the parameter is not sent
+    show_my_groups_only = case params do
+      %{"show_my_groups_only" => "true"} -> true
+      %{"show_my_groups_only" => show_my_groups} -> show_my_groups == "true"
+      _ -> false  # Checkbox unchecked - parameter not sent
+    end
     
     {:noreply,
      socket

--- a/lib/eventasaurus_web/live/group_live/index.html.heex
+++ b/lib/eventasaurus_web/live/group_live/index.html.heex
@@ -42,17 +42,18 @@
 
       <!-- Filter Controls -->
       <div class="flex items-center space-x-4">
-        <label class="flex items-center">
-          <input
-            type="checkbox"
-            phx-change="filter_my_groups"
-            name="show_my_groups_only"
-            value="true"
-            checked={@show_my_groups_only}
-            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
-          />
-          <span class="ml-2 text-sm text-gray-700 dark:text-gray-300">My Groups Only</span>
-        </label>
+        <form phx-change="filter_my_groups">
+          <label class="flex items-center">
+            <input
+              type="checkbox"
+              name="show_my_groups_only"
+              value="true"
+              checked={@show_my_groups_only}
+              class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
+            />
+            <span class="ml-2 text-sm text-gray-700 dark:text-gray-300">My Groups Only</span>
+          </label>
+        </form>
 
         <%= if @search_query != "" || @show_my_groups_only do %>
           <button


### PR DESCRIPTION
### TL;DR

Fixed group filtering functionality by improving checkbox handling and search parameter processing.

### What changed?

- Wrapped the "My Groups Only" checkbox in a form element to properly handle the phx-change event
- Enhanced the `handle_event("filter_my_groups")` function to handle cases when the checkbox is unchecked (parameter not sent)
- Added a new `handle_event("search")` function that handles different parameter formats for search queries
- Improved parameter handling to ensure proper behavior when clearing searches

### How to test?

1. Navigate to the Groups page
2. Test the "My Groups Only" checkbox - verify it works when checking and unchecking
3. Test the search functionality - verify it works when:
   - Entering a search query
   - Clearing a search query
   - Using the search with the filter checkbox in different states

### Why make this change?

The previous implementation had issues with checkbox state handling, particularly when unchecking the "My Groups Only" filter. The search functionality also needed improvement to handle different parameter formats. These changes ensure more robust filtering and searching behavior for the Groups page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search now reliably updates results and accepts input from varied form submissions.
  * “My Groups Only” filter consistently reflects checkbox state and updates results as expected.
  * Clearing filters works more predictably, ensuring lists refresh correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->