### PR TITLE
joining groups

### DIFF
--- a/lib/eventasaurus_app/groups/group_join_request.ex
+++ b/lib/eventasaurus_app/groups/group_join_request.ex
@@ -1,0 +1,61 @@
+defmodule EventasaurusApp.Groups.GroupJoinRequest do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias EventasaurusApp.Groups.Group
+  alias EventasaurusApp.Accounts.User
+
+  schema "group_join_requests" do
+    belongs_to :group, Group
+    belongs_to :user, User
+    field :status, :string, default: "pending"
+    field :message, :string
+    belongs_to :reviewed_by, User, foreign_key: :reviewed_by_id
+    field :reviewed_at, :utc_datetime
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @valid_statuses ["pending", "approved", "denied"]
+
+  @doc false
+  def changeset(group_join_request, attrs) do
+    group_join_request
+    |> cast(attrs, [:group_id, :user_id, :status, :message, :reviewed_by_id, :reviewed_at])
+    |> validate_required([:group_id, :user_id, :status])
+    |> validate_inclusion(:status, @valid_statuses)
+    |> foreign_key_constraint(:group_id)
+    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:reviewed_by_id)
+    |> unique_constraint([:group_id, :user_id],
+      name: :group_join_requests_unique_pending,
+      message: "You already have a pending request for this group"
+    )
+    |> validate_review_fields()
+  end
+
+  defp validate_review_fields(changeset) do
+    status = get_field(changeset, :status)
+    reviewed_by_id = get_field(changeset, :reviewed_by_id)
+    reviewed_at = get_field(changeset, :reviewed_at)
+
+    cond do
+      status in ["approved", "denied"] and is_nil(reviewed_by_id) ->
+        add_error(changeset, :reviewed_by_id, "must be present when status is #{status}")
+
+      status in ["approved", "denied"] and is_nil(reviewed_at) ->
+        add_error(changeset, :reviewed_at, "must be present when status is #{status}")
+
+      status == "pending" and not is_nil(reviewed_by_id) ->
+        add_error(changeset, :reviewed_by_id, "must be nil when status is pending")
+
+      status == "pending" and not is_nil(reviewed_at) ->
+        add_error(changeset, :reviewed_at, "must be nil when status is pending")
+
+      true ->
+        changeset
+    end
+  end
+
+  def valid_statuses, do: @valid_statuses
+end

--- a/priv/repo/migrations/20250905141021_create_group_join_requests.exs
+++ b/priv/repo/migrations/20250905141021_create_group_join_requests.exs
@@ -1,0 +1,30 @@
+defmodule EventasaurusApp.Repo.Migrations.CreateGroupJoinRequests do
+  use Ecto.Migration
+
+  def change do
+    create table(:group_join_requests) do
+      add :group_id, references(:groups, on_delete: :delete_all), null: false
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :status, :string, size: 20, default: "pending", null: false
+      add :message, :text
+      add :reviewed_by_id, references(:users, on_delete: :nilify_all)
+      add :reviewed_at, :utc_datetime
+
+      timestamps(type: :utc_datetime)
+    end
+
+    # Ensure user can only have one pending request per group
+    create unique_index(:group_join_requests, [:group_id, :user_id], 
+      where: "status = 'pending'", name: :group_join_requests_unique_pending)
+    
+    # Performance indexes
+    create index(:group_join_requests, [:group_id])
+    create index(:group_join_requests, [:user_id])
+    create index(:group_join_requests, [:status])
+    create index(:group_join_requests, [:reviewed_by_id])
+    
+    # Ensure valid status values
+    create constraint(:group_join_requests, :group_join_requests_status_check,
+      check: "status IN ('pending', 'approved', 'denied')")
+  end
+end


### PR DESCRIPTION
### TL;DR

Added group join request functionality to support different privacy levels for groups.

### What changed?

- Added a new `GroupJoinRequest` schema with associated database migration
- Implemented core join request functions in the Groups context:
  - Creating, approving, denying, and canceling join requests
  - Listing and filtering join requests by group, user, and status
  - Checking for pending requests
- Refactored the `add_user_to_group` function to respect group privacy settings:
  - Open groups: users can join immediately
  - Request-based groups: users must submit a join request first
  - Invite-only groups: only admins can add users
- Updated the dev seeds script to handle different group privacy levels

### How to test?

1. Run the migration to create the `group_join_requests` table
2. Test creating groups with different privacy settings (open, request-based, invite-only)
3. Try joining groups as different user types:
   - As a regular user trying to join an open group (should succeed immediately)
   - As a regular user trying to join a request-based group (should create a join request)
   - As a regular user trying to join an invite-only group (should fail)
   - As an admin adding users to any group type (should succeed)
4. Test the join request workflow:
   - Create join requests
   - Approve/deny requests as an admin
   - Cancel requests as the requesting user

### Why make this change?

This change enhances group privacy controls by implementing a proper join request system. It allows group administrators to review and approve membership requests before users can join, providing better control over group membership while still allowing for different levels of openness based on the group's privacy settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a request-to-join workflow for groups: users can submit and cancel join requests; admins can approve or deny.
  * Open groups now allow immediate joining; invite-only groups require admin action; group owners can add members directly.
  * Added views for pending join requests at both group and user levels, enabling better tracking and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->