### PR TITLE
pne more

### DIFF
--- a/lib/eventasaurus_web/live/group_live/index.ex
+++ b/lib/eventasaurus_web/live/group_live/index.ex
@@ -167,6 +167,7 @@ defmodule EventasaurusWeb.GroupLive.Index do
       {"unlisted", "request"} -> "🔗📝"
       {"unlisted", "invite_only"} -> "🔗📮"
       {"private", _} -> "🔒"
+      _ -> "❓"
     end
   end
 
@@ -179,6 +180,7 @@ defmodule EventasaurusWeb.GroupLive.Index do
       {"unlisted", "request"} -> "Unlisted - Request to join"
       {"unlisted", "invite_only"} -> "Unlisted - Invite only"
       {"private", _} -> "Private group"
+      _ -> "Unknown privacy settings"
     end
   end
 end

--- a/lib/eventasaurus_web/live/group_live/index.html.heex
+++ b/lib/eventasaurus_web/live/group_live/index.html.heex
@@ -164,9 +164,19 @@
                 <% end %>
                 <div class="mt-2 flex items-center space-x-2 text-sm text-gray-500 dark:text-gray-400">
                   <span><%= group.event_count %> <%= if group.event_count == 1, do: "event", else: "events" %></span>
-                  <span class="text-xs relative group/tooltip cursor-help">
+                  <span
+                    class="text-xs relative group/tooltip cursor-help"
+                    tabindex="0"
+                    aria-label={privacy_tooltip(group)}
+                    aria-describedby={"privacy_tt_#{group.id}"}
+                    title={privacy_tooltip(group)}
+                  >
                     <%= privacy_indicator(group) %>
-                    <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-xs rounded whitespace-nowrap opacity-0 invisible group-hover/tooltip:opacity-100 group-hover/tooltip:visible transition-opacity duration-200 z-10">
+                    <div
+                      id={"privacy_tt_#{group.id}"}
+                      role="tooltip"
+                      class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-900 text-white text-xs rounded whitespace-nowrap opacity-0 invisible group-hover/tooltip:opacity-100 group-hover/tooltip:visible group-focus/tooltip:opacity-100 group-focus/tooltip:visible transition-opacity duration-200 z-10"
+                    >
                       <%= privacy_tooltip(group) %>
                       <div class="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-900"></div>
                     </div>


### PR DESCRIPTION
### TL;DR

Added fallback handling for unknown privacy settings and improved tooltip accessibility.

### What changed?

- Added fallback cases to `privacy_indicator/1` and `privacy_tooltip/1` functions to handle unknown privacy settings with "❓" icon and "Unknown privacy settings" text
- Enhanced tooltip accessibility by adding:
  - `tabindex="0"` to make tooltips keyboard-focusable
  - `aria-label` and `title` attributes with the privacy tooltip text
  - `aria-describedby` attribute linking to the tooltip element
  - `role="tooltip"` to the tooltip element
  - CSS to show tooltips on focus (`:focus`) in addition to hover

### How to test?

1. Navigate to the groups page
2. Test keyboard navigation by tabbing to privacy indicators
3. Verify tooltips appear on both hover and keyboard focus
4. Verify screen readers can access the privacy information
5. If possible, test with a group that has non-standard privacy settings to confirm the fallback case works

### Why make this change?

This change improves the application's robustness by handling unexpected privacy settings gracefully instead of potentially crashing. It also enhances accessibility for keyboard users and screen reader users by making the privacy tooltips accessible without requiring a mouse hover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Group privacy tooltip is now keyboard-accessible and focusable.
  * Tooltip appears on both hover and focus, with improved visibility behavior.
  * Added ARIA attributes for better screen-reader support (aria-label, aria-describedby, role="tooltip").
* Bug Fixes
  * Displays a generic privacy indicator (“❓”) and “Unknown privacy settings” tooltip for unrecognized configurations, preventing broken UI states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->