### PR TITLE
polling

### DIFF
--- a/priv/repo/dev_seeds/enhanced_variety_polls.exs
+++ b/priv/repo/dev_seeds/enhanced_variety_polls.exs
@@ -1,0 +1,811 @@
+# Enhanced Variety Polls - Phase IV Implementation
+# This module creates comprehensive polling scenarios for testing
+
+# Load helpers if running independently
+unless Code.ensure_loaded?(DevSeeds.Helpers) do
+  Code.require_file("helpers.exs", __DIR__)
+end
+
+defmodule EnhancedVarietyPolls do
+  import Ecto.Query
+  alias EventasaurusApp.{Repo, Events, Accounts, Groups, Venues}
+  alias DevSeeds.Helpers
+
+  IO.puts("📦 EnhancedVarietyPolls module loaded")
+
+  @doc """
+  Creates comprehensive polling scenarios including:
+  - Multiple polls per event (3 polls)
+  - Different poll states (active, completed, draft)
+  - Various poll privacy settings
+  - Different group sizes and compositions
+  """
+  def run do
+    IO.puts("🚀 EnhancedVarietyPolls.run() called")
+    Helpers.section("Creating Phase IV: Enhanced Seed Variety")
+
+    users = get_available_users()
+    groups = get_available_groups()
+    venues = get_available_venues()
+
+    if length(users) < 10 do
+      Helpers.error("Not enough users available. Need at least 10 users.")
+      nil
+    else
+      # Create multi-poll events with different scenarios
+      create_triple_poll_conference_event(users, groups, venues)
+      create_wedding_planning_event(users, groups, venues)
+      create_startup_launch_event(users, groups, venues)
+      create_community_festival_event(users, groups, venues)
+      create_corporate_retreat_event(users, groups, venues)
+
+      Helpers.success("Enhanced variety polls created successfully!")
+    end
+  end
+
+  # Triple Poll Conference Event
+  defp create_triple_poll_conference_event(users, groups, venues) do
+    Helpers.log("→ Creating Tech Conference with 3 polls...")
+    
+    organizer = Enum.random(users)
+    group = Enum.random(groups)
+    venue = Enum.random(venues)
+    
+    # Create the event with proper image and venue using existing patterns
+    event_attrs = Map.merge(%{
+      title: "Annual Tech Conference 2025",
+      description: "A comprehensive tech conference covering AI, blockchain, and web development trends.",
+      start_at: DateTime.add(DateTime.utc_now(), 45 * 24 * 60 * 60), # 45 days from now
+      ends_at: DateTime.add(DateTime.utc_now(), 47 * 24 * 60 * 60), # 47 days from now
+      timezone: "America/New_York",
+      status: "confirmed",
+      taxation_type: "ticketed_event",
+      is_virtual: false,
+      venue_id: venue.id,
+      group_id: group.id
+    }, Helpers.get_random_image_attrs())
+
+    # Use Events.create_event API instead of factory for proper creation
+    event = case Events.create_event(event_attrs) do
+      {:ok, event} -> event
+      {:error, changeset} ->
+        Helpers.error("Failed to create conference event: #{inspect(changeset.errors)}")
+        nil
+    end
+    
+    if event do
+      # Add multiple participants with different group sizes
+      participants = Enum.take_random(users, 15)
+      Enum.each(participants, fn user ->
+        Events.create_event_participant(%{
+          event_id: event.id,
+          user_id: user.id,
+          status: "confirmed",
+          role: "participant"
+        })
+      end)
+
+      # Poll 1: Conference Track Selection (ACTIVE state)
+      create_conference_track_poll(event, organizer)
+      
+      # Poll 2: Keynote Speaker Preference (COMPLETED state)  
+      create_keynote_speaker_poll(event, organizer)
+      
+      # Poll 3: Workshop Time Slots (DRAFT state)
+      create_workshop_time_poll(event, organizer)
+
+      Helpers.success("  ✓ Tech Conference created with 3 polls (active, completed, draft)")
+    end
+  end
+
+  # Wedding Planning Event
+  defp create_wedding_planning_event(users, groups, venues) do
+    Helpers.log("→ Creating Wedding Planning with multiple polls...")
+    
+    organizer = Enum.random(users)
+    group = Enum.random(groups)
+    venue = Enum.random(venues)
+    
+    event_attrs = Map.merge(%{
+      title: "Sarah & Mike's Wedding Planning",
+      description: "Help us plan our dream wedding! Your input on venue, menu, and music is invaluable.",
+      start_at: DateTime.add(DateTime.utc_now(), 120 * 24 * 60 * 60), # 4 months from now
+      ends_at: DateTime.add(DateTime.utc_now(), 121 * 24 * 60 * 60),
+      timezone: "America/Los_Angeles",
+      status: "confirmed",
+      taxation_type: "ticketless",
+      is_virtual: false,
+      venue_id: venue.id,
+      group_id: group.id
+    }, Helpers.get_random_image_attrs())
+
+    event = case Events.create_event(event_attrs) do
+      {:ok, event} -> event
+      {:error, changeset} ->
+        Helpers.error("Failed to create wedding event: #{inspect(changeset.errors)}")
+        nil
+    end
+    
+    if event do
+      # Smaller, intimate group
+      participants = Enum.take_random(users, 8)
+      Enum.each(participants, fn user ->
+        Events.create_event_participant(%{
+          event_id: event.id,
+          user_id: user.id,
+          status: "confirmed",
+          role: "participant"
+        })
+      end)
+
+      # Wedding-specific polls with private settings
+      create_wedding_menu_poll(event, organizer)
+      create_wedding_music_poll(event, organizer)
+      create_wedding_photo_poll(event, organizer)
+
+      Helpers.success("  ✓ Wedding Planning created with 3 private polls")
+    end
+  end
+
+  # Startup Launch Event
+  defp create_startup_launch_event(users, groups, venues) do
+    Helpers.log("→ Creating Startup Launch with public polls...")
+    
+    organizer = Enum.random(users)
+    group = Enum.random(groups)
+    venue = Enum.random(venues)
+    
+    event_attrs = Map.merge(%{
+      title: "TechStartup Launch Event",
+      description: "Join us for the official launch of our revolutionary AI platform. Network, learn, and celebrate!",
+      start_at: DateTime.add(DateTime.utc_now(), 30 * 24 * 60 * 60), # 30 days from now
+      ends_at: DateTime.add(DateTime.utc_now(), 30 * 24 * 60 * 60 + 6 * 60 * 60), # +6 hours
+      timezone: "America/New_York",
+      status: "confirmed",
+      taxation_type: "ticketed_event",
+      is_virtual: false,
+      venue_id: venue.id,
+      group_id: group.id
+    }, Helpers.get_random_image_attrs())
+
+    event = case Events.create_event(event_attrs) do
+      {:ok, event} -> event
+      {:error, changeset} ->
+        Helpers.error("Failed to create startup event: #{inspect(changeset.errors)}")
+        nil
+    end
+    
+    if event do
+      # Large group - startup launch
+      participants = Enum.take_random(users, 25)
+      Enum.each(participants, fn user ->
+        Events.create_event_participant(%{
+          event_id: event.id,
+          user_id: user.id,
+          status: "confirmed",
+          role: "participant"
+        })
+      end)
+
+      # Public polls with different voting systems
+      create_startup_demo_poll(event, organizer)
+      create_networking_format_poll(event, organizer)
+      create_swag_preference_poll(event, organizer)
+
+      Helpers.success("  ✓ Startup Launch created with 3 public polls")
+    end
+  end
+
+  # Community Festival Event
+  defp create_community_festival_event(users, groups, venues) do
+    Helpers.log("→ Creating Community Festival with mixed poll states...")
+    
+    organizer = Enum.random(users)
+    group = Enum.random(groups)
+    venue = Enum.random(venues)
+    
+    event_attrs = Map.merge(%{
+      title: "Annual Community Arts Festival",
+      description: "Celebrate local talent with music, art, food, and family activities. Help us plan the perfect festival!",
+      start_at: DateTime.add(DateTime.utc_now(), 60 * 24 * 60 * 60), # 2 months from now
+      ends_at: DateTime.add(DateTime.utc_now(), 62 * 24 * 60 * 60), # 2 day festival
+      timezone: "America/Chicago",
+      status: "confirmed",
+      taxation_type: "ticketless",
+      is_virtual: false,
+      venue_id: venue.id,
+      group_id: group.id
+    }, Helpers.get_random_image_attrs())
+
+    event = case Events.create_event(event_attrs) do
+      {:ok, event} -> event
+      {:error, changeset} ->
+        Helpers.error("Failed to create community festival event: #{inspect(changeset.errors)}")
+        nil
+    end
+    
+    # Community-sized group
+    participants = Enum.take_random(users, 20)
+    Enum.each(participants, fn user ->
+      Events.create_event_participant(%{
+        event_id: event.id,
+        user_id: user.id,
+        status: "confirmed",
+        role: "participant"
+      })
+    end)
+
+    # Community polls with mixed settings
+    create_festival_activities_poll(event, organizer)
+    create_food_vendors_poll(event, organizer)
+    create_volunteer_shifts_poll(event, organizer)
+
+    Helpers.success("  ✓ Community Festival created with mixed poll privacy settings")
+  end
+
+  # Corporate Retreat Event  
+  defp create_corporate_retreat_event(users, groups, venues) do
+    Helpers.log("→ Creating Corporate Retreat with team-building polls...")
+    
+    organizer = Enum.random(users)
+    group = Enum.random(groups)
+    venue = Enum.random(venues)
+    
+    event_attrs = Map.merge(%{
+      title: "Q4 Corporate Team Retreat",
+      description: "Strategic planning and team building for Q4. Let's make decisions together on activities and logistics.",
+      start_at: DateTime.add(DateTime.utc_now(), 75 * 24 * 60 * 60), # 2.5 months from now
+      ends_at: DateTime.add(DateTime.utc_now(), 77 * 24 * 60 * 60), # 3 day retreat
+      timezone: "America/Denver",
+      status: "confirmed",
+      taxation_type: "ticketless",
+      is_virtual: false,
+      venue_id: venue.id,
+      group_id: group.id
+    }, Helpers.get_random_image_attrs())
+
+    event = case Events.create_event(event_attrs) do
+      {:ok, event} -> event
+      {:error, changeset} ->
+        Helpers.error("Failed to create corporate retreat event: #{inspect(changeset.errors)}")
+        nil
+    end
+    
+    # Corporate team size - only add participants if event was created successfully
+    if event do
+      participants = Enum.take_random(users, 12)
+      Enum.each(participants, fn user ->
+        Events.create_event_participant(%{
+          event_id: event.id,
+          user_id: user.id,
+          status: "confirmed",
+          role: "participant"
+        })
+      end)
+    end
+
+    # Corporate polls with restricted visibility - only if event was created
+    if event do
+      create_team_building_poll(event, organizer)
+      create_accommodation_poll(event, organizer) 
+      create_workshop_topics_poll(event, organizer)
+    end
+
+    Helpers.success("  ✓ Corporate Retreat created with 3 member-only polls")
+  end
+
+  # Specific poll creation functions - simplified to use the working API pattern
+
+  defp create_conference_track_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Which conference track interests you most?",
+      description: "Help us gauge interest for different technical tracks",
+      poll_type: "custom",
+      voting_system: "binary",
+      phase: "active",
+      auto_finalize: false,
+      privacy_settings: %{"visibility" => "public"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        # Create poll options
+        tracks = [
+          %{title: "AI & Machine Learning", description: "Latest developments in artificial intelligence"},
+          %{title: "Blockchain & Web3", description: "Decentralized applications and crypto"},
+          %{title: "Full-Stack Development", description: "Modern web development frameworks"},
+          %{title: "DevOps & Cloud", description: "Infrastructure and deployment strategies"},
+          %{title: "Mobile Development", description: "iOS and Android development trends"}
+        ]
+        
+        Enum.each(tracks, fn track ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: track.title,
+            description: track.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create conference track poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_keynote_speaker_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Vote for your preferred keynote speaker",
+      description: "These industry leaders have confirmed availability",
+      poll_type: "custom", 
+      voting_system: "ranked",
+      phase: "completed",
+      finalized_date: DateTime.add(DateTime.utc_now(), -7 * 24 * 60 * 60), # Completed 7 days ago
+      privacy_settings: %{"visibility" => "public"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        speakers = [
+          %{title: "Dr. Sarah Chen", description: "AI Ethics researcher at Stanford"},
+          %{title: "Marcus Rodriguez", description: "CTO of TechCorp, blockchain expert"},
+          %{title: "Lisa Park", description: "Founder of DevTools Inc."},
+          %{title: "Ahmed Hassan", description: "Principal Engineer at CloudFirst"}
+        ]
+        
+        Enum.each(speakers, fn speaker ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: speaker.title,
+            description: speaker.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create keynote speaker poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_workshop_time_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Preferred workshop time slots",
+      description: "When would you prefer hands-on workshops?",
+      poll_type: "time",
+      voting_system: "approval", 
+      phase: "draft",
+      max_options_per_user: 2,
+      privacy_settings: %{"visibility" => "public"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        time_slots = [
+          %{title: "Morning Session (9-11 AM)", description: "Early morning deep-dive sessions"},
+          %{title: "Late Morning (11 AM-1 PM)", description: "Pre-lunch workshop time"},
+          %{title: "Afternoon (2-4 PM)", description: "Post-lunch learning sessions"},
+          %{title: "Late Afternoon (4-6 PM)", description: "End-of-day practical workshops"}
+        ]
+        
+        Enum.each(time_slots, fn slot ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: slot.title,
+            description: slot.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create workshop time poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  # Simplified wedding polls
+  defp create_wedding_menu_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Wedding Reception Menu",
+      description: "Help us choose the perfect menu for our special day",
+      poll_type: "custom",
+      voting_system: "ranked",
+      phase: "active",
+      privacy_settings: %{"visibility" => "private"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        menus = [
+          %{title: "Mediterranean Feast", description: "Grilled fish, lamb, fresh vegetables, and baklava"},
+          %{title: "Classic American", description: "Roasted chicken, beef, mashed potatoes, wedding cake"},
+          %{title: "Italian Elegance", description: "Pasta bar, osso buco, tiramisu, wine pairings"},
+          %{title: "Fusion Experience", description: "Asian-Western fusion with unique flavor combinations"}
+        ]
+        
+        Enum.each(menus, fn menu ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: menu.title,
+            description: menu.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create wedding menu poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_wedding_music_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Reception Music Style",
+      description: "What music style should dominate our reception?",
+      poll_type: "custom",
+      voting_system: "binary",
+      phase: "active",
+      privacy_settings: %{"visibility" => "private"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        styles = [
+          %{title: "Classic Rock & Pop", description: "Timeless hits everyone can dance to"},
+          %{title: "Jazz & Swing", description: "Elegant and sophisticated atmosphere"},
+          %{title: "Modern Top 40", description: "Current hits and dance music"},
+          %{title: "Mixed Decades", description: "Something for every generation"}
+        ]
+        
+        Enum.each(styles, fn style ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: style.title,
+            description: style.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create wedding music poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_wedding_photo_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Photo Session Locations",
+      description: "Where should we do our couple photo session?",
+      poll_type: "places",
+      voting_system: "approval",
+      phase: "draft",
+      max_options_per_user: 2,
+      privacy_settings: %{"visibility" => "private"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        locations = [
+          %{title: "Beach Sunset", description: "Golden hour photos by the ocean"},
+          %{title: "Urban Downtown", description: "City skyline and architecture"},
+          %{title: "Garden/Park", description: "Natural greenery and flowers"},
+          %{title: "Historic Venue", description: "Classic architecture and charm"}
+        ]
+        
+        Enum.each(locations, fn location ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: location.title,
+            description: location.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create wedding photo poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  # Additional simplified poll creation methods
+  defp create_startup_demo_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Most Exciting Demo Feature",
+      description: "Which feature demo are you most excited to see?",
+      poll_type: "star_rating",
+      voting_system: "star_rating",
+      phase: "active",
+      privacy_settings: %{"visibility" => "public"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        features = [
+          %{title: "AI-Powered Analytics", description: "Real-time data insights and predictions"},
+          %{title: "Seamless Integrations", description: "Connect with 50+ popular tools"},
+          %{title: "Mobile App Experience", description: "Native iOS and Android applications"},
+          %{title: "Enterprise Security", description: "SOC2 compliance and data protection"}
+        ]
+        
+        Enum.each(features, fn feature ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: feature.title,
+            description: feature.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create startup demo poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_networking_format_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Networking Format Preference",
+      description: "How would you prefer to network at our launch event?",
+      poll_type: "custom",
+      voting_system: "binary",
+      phase: "active",
+      privacy_settings: %{"visibility" => "public"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        formats = [
+          %{title: "Speed Networking", description: "Structured 5-minute conversations"},
+          %{title: "Open Networking", description: "Free-form mingling and conversations"},
+          %{title: "Topic Tables", description: "Sit at tables based on interests"},
+          %{title: "Industry Meetups", description: "Group by industry/role"}
+        ]
+        
+        Enum.each(formats, fn format ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: format.title,
+            description: format.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create networking format poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_swag_preference_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Preferred Event Swag",
+      description: "What swag would you actually use? (Poll closed - results final)",
+      poll_type: "custom",
+      voting_system: "approval", 
+      phase: "completed",
+      max_options_per_user: 3,
+      finalized_date: DateTime.add(DateTime.utc_now(), -14 * 24 * 60 * 60), # Completed 2 weeks ago
+      privacy_settings: %{"visibility" => "public"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        swag_items = [
+          %{title: "Premium T-Shirt", description: "High-quality cotton tee with logo"},
+          %{title: "Insulated Coffee Mug", description: "Perfect for your morning coffee"},
+          %{title: "Wireless Phone Charger", description: "Practical tech accessory"},
+          %{title: "Laptop Sticker Pack", description: "Show off your tech stack"},
+          %{title: "Notebook & Pen Set", description: "Classic professional combo"}
+        ]
+        
+        Enum.each(swag_items, fn item ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: item.title,
+            description: item.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create swag preference poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_festival_activities_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Festival Activity Priorities",
+      description: "Help us prioritize which activities to include",
+      poll_type: "custom",
+      voting_system: "ranked",
+      phase: "active",
+      privacy_settings: %{"visibility" => "public"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        activities = [
+          %{title: "Live Music Stage", description: "Local bands and performers"},
+          %{title: "Art Gallery Tent", description: "Local artists displaying work"},
+          %{title: "Kids Activity Zone", description: "Family-friendly games and crafts"},
+          %{title: "Food Truck Row", description: "Diverse local food vendors"},
+          %{title: "Community Garden Tour", description: "Educational garden walkthrough"}
+        ]
+        
+        Enum.each(activities, fn activity ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: activity.title,
+            description: activity.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create festival activities poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_food_vendors_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Food Vendor Selection",
+      description: "Voting completed - these vendors are confirmed!",
+      poll_type: "places",
+      voting_system: "approval",
+      phase: "completed",
+      max_options_per_user: 4,
+      finalized_date: DateTime.add(DateTime.utc_now(), -21 * 24 * 60 * 60), # Completed 3 weeks ago
+      privacy_settings: %{"visibility" => "members_only"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        vendors = [
+          %{title: "Mario's Pizza Truck", description: "Wood-fired pizza with local ingredients"},
+          %{title: "Seoul Kitchen", description: "Korean BBQ and kimchi tacos"},
+          %{title: "Sweet Treats Bakery", description: "Artisan desserts and coffee"},
+          %{title: "Green Valley Farm Stand", description: "Fresh vegetables and smoothies"},
+          %{title: "BBQ Brothers", description: "Smoked meats and classic sides"}
+        ]
+        
+        Enum.each(vendors, fn vendor ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: vendor.title,
+            description: vendor.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create food vendors poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_volunteer_shifts_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Volunteer Shift Availability",
+      description: "Sign up for volunteer shifts (draft - not yet open)",
+      poll_type: "time",
+      voting_system: "approval",
+      phase: "draft",
+      max_options_per_user: 3,
+      privacy_settings: %{"visibility" => "public"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        shifts = [
+          %{title: "Setup Crew (Friday 6-10 PM)", description: "Help set up stages and booths"},
+          %{title: "Saturday Morning (8 AM-12 PM)", description: "Festival opening and crowd control"},
+          %{title: "Saturday Afternoon (12-6 PM)", description: "Peak hours support"},
+          %{title: "Saturday Evening (6-10 PM)", description: "Evening activities and cleanup prep"},
+          %{title: "Teardown (Sunday 8 AM-12 PM)", description: "Post-festival cleanup"}
+        ]
+        
+        Enum.each(shifts, fn shift ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: shift.title,
+            description: shift.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create volunteer shifts poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_team_building_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Team Building Activity Preference",
+      description: "What team building activities would be most valuable?",
+      poll_type: "custom",
+      voting_system: "ranked",
+      phase: "active",
+      privacy_settings: %{"visibility" => "members_only"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        activities = [
+          %{title: "Outdoor Adventure Course", description: "Rope climbing, obstacles, teamwork challenges"},
+          %{title: "Escape Room Challenge", description: "Problem-solving under pressure"},
+          %{title: "Cooking Class Competition", description: "Collaborative meal preparation"},
+          %{title: "Innovation Workshop", description: "Brainstorming and creative problem solving"},
+          %{title: "Volunteer Service Project", description: "Give back to the local community"}
+        ]
+        
+        Enum.each(activities, fn activity ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: activity.title,
+            description: activity.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create team building poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_accommodation_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Accommodation Preferences",
+      description: "Help us arrange the best lodging for everyone",
+      poll_type: "venue",
+      voting_system: "binary", 
+      phase: "active",
+      privacy_settings: %{"visibility" => "members_only"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        accommodations = [
+          %{title: "Resort Hotel", description: "All-inclusive with spa and amenities"},
+          %{title: "Mountain Lodge", description: "Rustic charm with hiking access"},
+          %{title: "Boutique Hotel", description: "Unique local character and style"},
+          %{title: "Corporate Retreat Center", description: "Meeting rooms and business facilities"}
+        ]
+        
+        Enum.each(accommodations, fn accommodation ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: accommodation.title,
+            description: accommodation.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create accommodation poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  defp create_workshop_topics_poll(event, organizer) do
+    case Events.create_poll(%{
+      event_id: event.id,
+      title: "Professional Development Workshop Topics",
+      description: "What skills would be most valuable to develop? (Planning phase)",
+      poll_type: "custom",
+      voting_system: "approval",
+      phase: "draft",
+      max_options_per_user: 3,
+      privacy_settings: %{"visibility" => "members_only"},
+      created_by_id: organizer.id
+    }) do
+      {:ok, poll} ->
+        topics = [
+          %{title: "Leadership & Management", description: "Leading teams and managing projects"},
+          %{title: "Communication Skills", description: "Presentation and interpersonal skills"},
+          %{title: "Strategic Planning", description: "Long-term thinking and goal setting"},
+          %{title: "Innovation & Creativity", description: "Design thinking and creative problem solving"},
+          %{title: "Data Analysis & Insights", description: "Making data-driven decisions"}
+        ]
+        
+        Enum.each(topics, fn topic ->
+          Events.create_poll_option(%{
+            poll_id: poll.id,
+            title: topic.title,
+            description: topic.description
+          })
+        end)
+
+      {:error, changeset} ->
+        Helpers.error("Failed to create workshop topics poll: #{inspect(changeset.errors)}")
+    end
+  end
+
+  # Helper functions to get existing data
+  defp get_available_users do
+    Repo.all(from u in Accounts.User, limit: 50)
+  end
+
+  defp get_available_groups do
+    Repo.all(from g in Groups.Group, where: is_nil(g.deleted_at), limit: 10)
+  end
+
+  defp get_available_venues do
+    Repo.all(from v in Venues.Venue, limit: 20)
+  end
+end

--- a/priv/repo/dev_seeds/runner.exs
+++ b/priv/repo/dev_seeds/runner.exs
@@ -112,6 +112,15 @@ Code.require_file("activity_seed.exs", __DIR__)
 ActivitySeed.run()
 activities = Repo.all(EventasaurusApp.Events.EventActivity)
 
+# Create Phase IV: Enhanced Variety Polls
+Helpers.section("Creating Phase IV: Enhanced Variety Polls")
+Code.require_file("enhanced_variety_polls.exs", __DIR__)
+if Code.ensure_loaded?(EnhancedVarietyPolls) and function_exported?(EnhancedVarietyPolls, :run, 0) do
+  EnhancedVarietyPolls.run()
+else
+  Helpers.error("EnhancedVarietyPolls module not properly loaded")
+end
+
 # Validate seeding consistency
 Helpers.section("Validating Seeding Consistency")
 import Ecto.Query

--- a/priv/repo/dev_seeds/services/event_builder.ex
+++ b/priv/repo/dev_seeds/services/event_builder.ex
@@ -1,0 +1,109 @@
+defmodule DevSeeds.EventBuilder do
+  @moduledoc """
+  Centralized service for creating events with all required attributes.
+  Ensures consistency across all seed modules.
+  
+  This service coordinates with other specialized services to ensure
+  every event has proper images, venues, and all required attributes.
+  """
+  
+  import EventasaurusApp.Factory
+  alias DevSeeds.{ImageService, VenueService, EventTypes}
+  
+  @doc """
+  Creates an event with all required attributes using centralized logic.
+  
+  ## Parameters
+  - event_type: atom representing the event type (:conference, :wedding, etc.)
+  - base_attrs: map of base attributes for the event
+  - options: keyword list of options
+    - virtual: boolean to force virtual event (default: false)
+    - image_category: override default image category for event type
+    
+  ## Examples
+    
+      # Create a physical conference event
+      event = DevSeeds.EventBuilder.create_event(:conference, %{
+        title: "Tech Conference 2025",
+        description: "Annual technology conference"
+      })
+      
+      # Create a virtual wedding planning event
+      event = DevSeeds.EventBuilder.create_event(:wedding, %{
+        title: "Wedding Planning Session"
+      }, virtual: true)
+  """
+  def create_event(event_type, base_attrs \\ %{}, options \\ []) do
+    # Get configuration for this event type
+    config = EventTypes.get_configuration(event_type)
+    
+    # Build complete attributes by merging in order of priority:
+    # 1. Event type defaults
+    # 2. Image attributes
+    # 3. Venue attributes  
+    # 4. User-provided base_attrs (highest priority)
+    config.default_attrs
+    |> Map.merge(ImageService.get_image_attributes(event_type, options))
+    |> Map.merge(VenueService.get_venue_attributes(event_type, options))
+    |> Map.merge(base_attrs)
+    |> create_realistic_event()
+  end
+  
+  @doc """
+  Creates multiple events of the same type with varied attributes.
+  
+  ## Parameters
+  - event_type: atom representing the event type
+  - count: number of events to create
+  - attrs_fn: function that takes index and returns attributes map
+  - options: keyword list passed to create_event/3
+  
+  ## Examples
+  
+      events = DevSeeds.EventBuilder.create_events(:conference, 3, fn i ->
+        %{title: "Conference \#{i}", capacity: 50 + i * 10}
+      end)
+  """
+  def create_events(event_type, count, attrs_fn \\ fn _i -> %{} end, options \\ []) do
+    Enum.map(1..count, fn i ->
+      attrs = attrs_fn.(i)
+      create_event(event_type, attrs, options)
+    end)
+  end
+  
+  @doc """
+  Creates an event with polls using the centralized system.
+  
+  This is a convenience function that creates an event and then
+  adds polls to it using the poll creation services.
+  
+  ## Parameters
+  - event_type: atom representing the event type
+  - base_attrs: map of base attributes for the event
+  - poll_configs: list of poll configuration maps
+  - options: keyword list passed to create_event/3
+  
+  ## Examples
+  
+      event = DevSeeds.EventBuilder.create_event_with_polls(:conference, %{
+        title: "Tech Summit 2025"
+      }, [
+        %{poll_type: "date_selection", title: "Choose Conference Date"},
+        %{poll_type: "places", title: "Select Venue Location"}
+      ])
+  """
+  def create_event_with_polls(event_type, base_attrs, poll_configs, options \\ []) do
+    # Create the event first
+    event = create_event(event_type, base_attrs, options)
+    
+    # Add polls to the event (this will be implemented when we add poll services)
+    # For now, return the event - polls will be added by existing poll creation logic
+    event
+  end
+  
+  # Private function to create the actual event using factory
+  # Uses :realistic_event factory which should include proper defaults
+  defp create_realistic_event(attrs) do
+    insert(:realistic_event, attrs)
+  end
+end

--- a/priv/repo/dev_seeds/services/event_types.ex
+++ b/priv/repo/dev_seeds/services/event_types.ex
@@ -1,0 +1,366 @@
+defmodule DevSeeds.EventTypes do
+  @moduledoc """
+  Configuration module for different event types.
+  
+  This module defines the characteristics, defaults, and requirements
+  for different types of events used in seed generation.
+  """
+  
+  @doc """
+  Gets the configuration for a specific event type.
+  
+  ## Parameters
+  - event_type: atom representing the event type
+  
+  ## Returns
+  Map containing configuration for the event type including:
+  - default_attrs: default attributes for events of this type
+  - requires_venue: whether physical venue is typically required
+  - image_category: default image category
+  - typical_capacity: typical capacity range
+  - default_status: default event status
+  - description_templates: templates for generating descriptions
+  
+  ## Examples
+  
+      config = DevSeeds.EventTypes.get_configuration(:conference)
+      # => %{
+      #   default_attrs: %{status: :confirmed, category: "business"},
+      #   requires_venue: true,
+      #   image_category: "business",
+      #   typical_capacity: 200,
+      #   ...
+      # }
+  """
+  def get_configuration(event_type) do
+    Map.get(configurations(), event_type, get_configuration(:general))
+  end
+  
+  @doc """
+  Gets all available event type configurations.
+  
+  ## Returns
+  Map with event type atoms as keys and configuration maps as values
+  """
+  def all_configurations() do
+    configurations()
+  end
+  
+  @doc """
+  Gets list of all available event types.
+  
+  ## Returns
+  List of event type atoms
+  """
+  def available_types() do
+    Map.keys(configurations())
+  end
+  
+  @doc """
+  Checks if an event type is defined.
+  
+  ## Parameters
+  - event_type: atom to check
+  
+  ## Returns
+  Boolean indicating if event type is defined
+  """
+  def valid_type?(event_type) do
+    Map.has_key?(configurations(), event_type)
+  end
+  
+  # Private function containing all event type configurations
+  defp configurations() do
+    %{
+      # Business Events
+      conference: %{
+        default_attrs: %{
+          status: :confirmed,
+          category: "business",
+          visibility: "public",
+          is_ticketed: true,
+          taxation_type: "business"
+        },
+        requires_venue: true,
+        image_category: "business",
+        typical_capacity: 200,
+        description_templates: [
+          "Join industry leaders for this comprehensive conference on cutting-edge topics.",
+          "Network with professionals and learn from expert speakers.",
+          "Discover the latest trends and innovations in the industry."
+        ]
+      },
+      
+      networking: %{
+        default_attrs: %{
+          status: :confirmed,
+          category: "business", 
+          visibility: "public",
+          is_ticketed: true,
+          taxation_type: "business"
+        },
+        requires_venue: true,
+        image_category: "business",
+        typical_capacity: 80,
+        description_templates: [
+          "Connect with like-minded professionals in a relaxed atmosphere.",
+          "Expand your network and discover new business opportunities.",
+          "Meet industry peers and share experiences over refreshments."
+        ]
+      },
+      
+      launch: %{
+        default_attrs: %{
+          status: :polling,
+          category: "business",
+          visibility: "public", 
+          is_ticketed: true,
+          taxation_type: "business"
+        },
+        requires_venue: true,
+        image_category: "business",
+        typical_capacity: 120,
+        description_templates: [
+          "Be among the first to experience our latest product launch.",
+          "Join us for an exclusive preview of exciting new innovations.",
+          "Celebrate with us as we unveil our next breakthrough."
+        ]
+      },
+      
+      # Educational Events  
+      workshop: %{
+        default_attrs: %{
+          status: :confirmed,
+          category: "education",
+          visibility: "public",
+          is_ticketed: true,
+          taxation_type: "education"
+        },
+        requires_venue: true,
+        image_category: "education", 
+        typical_capacity: 30,
+        description_templates: [
+          "Hands-on workshop to develop practical skills and knowledge.",
+          "Interactive learning experience with expert instructors.",
+          "Master new techniques through guided practice and exercises."
+        ]
+      },
+      
+      seminar: %{
+        default_attrs: %{
+          status: :confirmed,
+          category: "education",
+          visibility: "public",
+          is_ticketed: true,
+          taxation_type: "education"
+        },
+        requires_venue: true,
+        image_category: "education",
+        typical_capacity: 75,
+        description_templates: [
+          "Educational seminar featuring renowned experts and thought leaders.",
+          "Deep dive into specialized topics with comprehensive coverage.",
+          "Gain insights and knowledge from industry professionals."
+        ]
+      },
+      
+      # Social Events
+      wedding: %{
+        default_attrs: %{
+          status: :polling,
+          category: "personal",
+          visibility: "private",
+          is_ticketed: false,
+          taxation_type: "personal"
+        },
+        requires_venue: true,
+        image_category: "celebration",
+        typical_capacity: 150,
+        description_templates: [
+          "Celebrate this special day with family and friends.",
+          "Join us for a beautiful wedding ceremony and reception.",
+          "Share in the joy and love of this memorable occasion."
+        ]
+      },
+      
+      party: %{
+        default_attrs: %{
+          status: :confirmed,
+          category: "social",
+          visibility: "private",
+          is_ticketed: false,
+          taxation_type: "personal"
+        },
+        requires_venue: true,
+        image_category: "celebration",
+        typical_capacity: 100,
+        description_templates: [
+          "Join us for an unforgettable celebration with friends.",
+          "Party the night away with great music, food, and company.",
+          "Come celebrate this special occasion with us."
+        ]
+      },
+      
+      meetup: %{
+        default_attrs: %{
+          status: :confirmed,
+          category: "social",
+          visibility: "public",
+          is_ticketed: false,
+          taxation_type: "personal"
+        },
+        requires_venue: true,
+        image_category: "social",
+        typical_capacity: 50,
+        description_templates: [
+          "Casual meetup for interesting conversations and connections.",
+          "Come hang out with fellow enthusiasts and share experiences.",
+          "Relaxed gathering to meet new people and have fun."
+        ]
+      },
+      
+      # Entertainment Events
+      festival: %{
+        default_attrs: %{
+          status: :confirmed,
+          category: "entertainment",
+          visibility: "public",
+          is_ticketed: true,
+          taxation_type: "entertainment"
+        },
+        requires_venue: true,
+        image_category: "entertainment",
+        typical_capacity: 500,
+        description_templates: [
+          "Multi-day festival featuring amazing performances and activities.",
+          "Immerse yourself in art, music, and cultural experiences.",
+          "Celebrate community and creativity at this vibrant festival."
+        ]
+      },
+      
+      # Wellness Events
+      retreat: %{
+        default_attrs: %{
+          status: :polling,
+          category: "wellness",
+          visibility: "public",
+          is_ticketed: true,
+          taxation_type: "wellness"
+        },
+        requires_venue: true,
+        image_category: "wellness", 
+        typical_capacity: 40,
+        description_templates: [
+          "Rejuvenating retreat to reconnect with yourself and nature.",
+          "Escape the daily grind and focus on personal well-being.",
+          "Transform your mind and body in a peaceful setting."
+        ]
+      },
+      
+      # Virtual Events
+      webinar: %{
+        default_attrs: %{
+          status: :confirmed,
+          category: "education",
+          visibility: "public",
+          is_ticketed: true,
+          taxation_type: "education",
+          is_virtual: true
+        },
+        requires_venue: false,
+        image_category: "education",
+        typical_capacity: 500,
+        description_templates: [
+          "Interactive online presentation with expert speakers.",
+          "Learn from anywhere with this comprehensive webinar.",
+          "Join remotely for valuable insights and Q&A sessions."
+        ]
+      },
+      
+      online_course: %{
+        default_attrs: %{
+          status: :confirmed,
+          category: "education", 
+          visibility: "public",
+          is_ticketed: true,
+          taxation_type: "education",
+          is_virtual: true
+        },
+        requires_venue: false,
+        image_category: "education",
+        typical_capacity: 200,
+        description_templates: [
+          "Comprehensive online course with structured learning modules.",
+          "Master new skills through self-paced online instruction.",
+          "Interactive digital learning experience with expert guidance."
+        ]
+      },
+      
+      # Default/General type for fallback
+      general: %{
+        default_attrs: %{
+          status: :draft,
+          category: "general",
+          visibility: "public",
+          is_ticketed: false,
+          taxation_type: "general"
+        },
+        requires_venue: true,
+        image_category: "general",
+        typical_capacity: 100,
+        description_templates: [
+          "Join us for this exciting event.",
+          "Be part of something special.",
+          "Don't miss this unique opportunity."
+        ]
+      }
+    }
+  end
+  
+  @doc """
+  Generates a description for an event based on its type.
+  
+  ## Parameters  
+  - event_type: atom representing the event type
+  - custom_context: optional string to customize the description
+  
+  ## Returns
+  String description appropriate for the event type
+  """
+  def generate_description(event_type, custom_context \\ nil) do
+    config = get_configuration(event_type)
+    templates = config.description_templates
+    
+    base_description = Enum.random(templates)
+    
+    if custom_context do
+      base_description <> " " <> custom_context
+    else
+      base_description
+    end
+  end
+  
+  @doc """
+  Gets appropriate timezone for an event type.
+  
+  ## Parameters
+  - event_type: atom representing the event type
+  - location: optional location hint
+  
+  ## Returns
+  String timezone identifier
+  """
+  def get_timezone(event_type, location \\ nil) do
+    # This could be more sophisticated based on venue location
+    # For now, default to common US timezones based on event type
+    
+    case {event_type, location} do
+      {:webinar, _} -> "UTC" # Virtual events often use UTC
+      {:online_course, _} -> "UTC"
+      {_, "San Francisco"} -> "America/Los_Angeles"
+      {_, "Los Angeles"} -> "America/Los_Angeles" 
+      {_, "San Diego"} -> "America/Los_Angeles"
+      {_, _} -> "America/Los_Angeles" # Default to Pacific for seed data
+    end
+  end
+end

--- a/priv/repo/dev_seeds/services/image_service.ex
+++ b/priv/repo/dev_seeds/services/image_service.ex
@@ -1,0 +1,139 @@
+defmodule DevSeeds.ImageService do
+  @moduledoc """
+  Centralized service for handling event image assignment.
+  
+  This service ensures that all events get appropriate images based on
+  their type, category, and other characteristics. It provides fallbacks
+  and handles the existing DefaultImagesService integration.
+  """
+  
+  @doc """
+  Gets image attributes for an event based on its type and options.
+  
+  ## Parameters
+  - event_type: atom representing the event type (:conference, :wedding, etc.)
+  - options: keyword list of options
+    - image_category: override the default image category
+    - force_fallback: boolean to force using fallback image
+    
+  ## Returns
+  Map with cover_image_url and potentially other image-related attributes
+  
+  ## Examples
+  
+      # Get image for a conference event
+      attrs = DevSeeds.ImageService.get_image_attributes(:conference)
+      # => %{cover_image_url: "/images/events/business/conference.png"}
+      
+      # Override image category
+      attrs = DevSeeds.ImageService.get_image_attributes(:wedding, image_category: "celebration")
+  """
+  def get_image_attributes(event_type, options \\ []) do
+    image_category = Keyword.get(options, :image_category) || get_default_image_category(event_type)
+    force_fallback = Keyword.get(options, :force_fallback, false)
+    
+    if force_fallback do
+      get_fallback_image()
+    else
+      get_image_for_category(image_category) || get_fallback_image()
+    end
+  end
+  
+  @doc """
+  Gets a random image from the DefaultImagesService or returns fallback.
+  
+  This maintains compatibility with the existing image system while
+  providing guaranteed fallbacks.
+  """
+  def get_random_image_attributes() do
+    alias EventasaurusWeb.Services.DefaultImagesService
+    
+    case DefaultImagesService.get_random_image() do
+      nil ->
+        get_fallback_image()
+      
+      image ->
+        %{cover_image_url: image.url}
+    end
+  end
+  
+  # Private functions
+  
+  # Maps event types to appropriate image categories
+  defp get_default_image_category(:conference), do: "business"
+  defp get_default_image_category(:wedding), do: "celebration"  
+  defp get_default_image_category(:workshop), do: "education"
+  defp get_default_image_category(:meetup), do: "social"
+  defp get_default_image_category(:party), do: "celebration"
+  defp get_default_image_category(:festival), do: "entertainment"
+  defp get_default_image_category(:seminar), do: "education"
+  defp get_default_image_category(:retreat), do: "wellness"
+  defp get_default_image_category(:networking), do: "business"
+  defp get_default_image_category(:launch), do: "business"
+  defp get_default_image_category(_), do: "general"
+  
+  # Attempts to get an image for a specific category
+  # Currently uses the random image service, but could be extended
+  # to support category-specific selection
+  defp get_image_for_category(_category) do
+    alias EventasaurusWeb.Services.DefaultImagesService
+    
+    case DefaultImagesService.get_random_image() do
+      nil -> nil
+      image -> %{cover_image_url: image.url}
+    end
+  end
+  
+  # Provides a guaranteed fallback image that should always work
+  defp get_fallback_image() do
+    %{cover_image_url: "/images/events/general/high-five-dino.png"}
+  end
+  
+  @doc """
+  Validates that an event has a proper image assigned.
+  
+  ## Parameters
+  - event: event struct or map with image attributes
+  
+  ## Returns
+  - {:ok, event} if image is valid
+  - {:error, reason} if image is missing or invalid
+  """
+  def validate_event_image(event) do
+    case Map.get(event, :cover_image_url) do
+      nil ->
+        {:error, "Event missing cover_image_url"}
+        
+      "" ->
+        {:error, "Event has empty cover_image_url"}
+        
+      url when is_binary(url) ->
+        {:ok, event}
+        
+      _ ->
+        {:error, "Event has invalid cover_image_url type"}
+    end
+  end
+  
+  @doc """
+  Fixes an event's image if it's missing or invalid.
+  
+  ## Parameters  
+  - event: event struct or map
+  - event_type: atom representing event type for appropriate image selection
+  
+  ## Returns
+  Updated event with proper image attributes
+  """
+  def ensure_event_has_image(event, event_type \\ :general) do
+    case validate_event_image(event) do
+      {:ok, _} -> 
+        event  # Image is fine, return as-is
+        
+      {:error, _reason} ->
+        # Image is missing/invalid, add a new one
+        image_attrs = get_image_attributes(event_type)
+        Map.merge(event, image_attrs)
+    end
+  end
+end

--- a/priv/repo/dev_seeds/services/validator.ex
+++ b/priv/repo/dev_seeds/services/validator.ex
@@ -1,0 +1,299 @@
+defmodule DevSeeds.Validator do
+  @moduledoc """
+  Validation service for seed generation.
+  
+  This module provides functions to validate that seeded events
+  have all required attributes and are properly configured.
+  """
+  
+  import Ecto.Query
+  alias EventasaurusApp.Repo
+  alias EventasaurusApp.Events.{Event, Poll, EventParticipant}
+  alias DevSeeds.{ImageService, VenueService, Helpers}
+  
+  @doc """
+  Validates all events in the database and reports issues.
+  
+  ## Returns
+  - {:ok, stats} if validation passes
+  - {:error, issues} if validation finds problems
+  
+  Stats include:
+  - total_events: number of events checked
+  - events_with_issues: number of events with problems
+  - issues: list of issue descriptions
+  """
+  def validate_all_events() do
+    events = Repo.all(from e in Event, where: is_nil(e.deleted_at))
+    
+    {valid_events, issues} = 
+      events
+      |> Enum.map(&validate_event/1)
+      |> Enum.reduce({[], []}, fn
+        {:ok, event}, {valid, issues} -> {[event | valid], issues}
+        {:error, event_issues}, {valid, issues} -> {valid, issues ++ event_issues}
+      end)
+    
+    stats = %{
+      total_events: length(events),
+      valid_events: length(valid_events),
+      events_with_issues: length(events) - length(valid_events),
+      issues: issues
+    }
+    
+    if length(issues) == 0 do
+      {:ok, stats}
+    else
+      {:error, stats}
+    end
+  end
+  
+  @doc """
+  Validates a single event for all required attributes.
+  
+  ## Parameters
+  - event: Event struct to validate
+  
+  ## Returns
+  - {:ok, event} if event is valid
+  - {:error, [issues]} if event has problems
+  """
+  def validate_event(event) do
+    checks = [
+      check_has_required_fields(event),
+      check_image_validity(event),
+      check_venue_consistency(event),
+      check_datetime_validity(event),
+      check_status_validity(event)
+    ]
+    
+    issues = Enum.filter(checks, fn {result, _} -> result == :error end)
+             |> Enum.map(fn {_, issue} -> "Event #{event.id} (#{event.title}): #{issue}" end)
+    
+    if length(issues) == 0 do
+      {:ok, event}
+    else
+      {:error, issues}
+    end
+  end
+  
+  @doc """
+  Runs validation and prints a report to console.
+  
+  This is useful for manual testing and debugging.
+  """
+  def run_validation_report() do
+    Helpers.section("Seed Validation Report")
+    
+    case validate_all_events() do
+      {:ok, stats} ->
+        Helpers.success("✅ All #{stats.total_events} events passed validation!")
+        
+      {:error, stats} ->
+        Helpers.error("❌ Found issues with #{stats.events_with_issues}/#{stats.total_events} events:")
+        Enum.each(stats.issues, fn issue ->
+          Helpers.log("  - #{issue}", :red)
+        end)
+        
+        # Suggest fixes
+        Helpers.log("\nSuggested fixes:", :yellow)
+        suggest_fixes(stats.issues)
+    end
+  end
+  
+  @doc """
+  Attempts to automatically fix common issues with events.
+  
+  ## Parameters
+  - fix_types: list of issue types to fix (:images, :venues, :all)
+  
+  ## Returns
+  - {:ok, fixes_applied} if fixes were successful
+  - {:error, reason} if fixes failed
+  """
+  def auto_fix_issues(fix_types \\ [:images, :venues]) do
+    events = Repo.all(from e in Event, where: is_nil(e.deleted_at))
+    
+    fixes_applied = 
+      events
+      |> Enum.flat_map(fn event ->
+        apply_fixes_to_event(event, fix_types)
+      end)
+    
+    if length(fixes_applied) > 0 do
+      Helpers.success("Applied #{length(fixes_applied)} fixes:")
+      Enum.each(fixes_applied, fn fix ->
+        Helpers.log("  ✓ #{fix}")
+      end)
+    end
+    
+    {:ok, fixes_applied}
+  end
+  
+  # Private validation functions
+  
+  defp check_has_required_fields(event) do
+    required_fields = [:title, :description, :start_at, :status]
+    
+    missing_fields = Enum.filter(required_fields, fn field ->
+      value = Map.get(event, field)
+      is_nil(value) or (is_binary(value) and String.trim(value) == "")
+    end)
+    
+    if length(missing_fields) == 0 do
+      {:ok, "Required fields present"}
+    else
+      {:error, "Missing required fields: #{Enum.join(missing_fields, ", ")}"}
+    end
+  end
+  
+  defp check_image_validity(event) do
+    case ImageService.validate_event_image(event) do
+      {:ok, _} -> {:ok, "Image valid"}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+  
+  defp check_venue_consistency(event) do
+    case VenueService.validate_event_venue(event) do
+      {:ok, _} -> {:ok, "Venue valid"}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+  
+  defp check_datetime_validity(event) do
+    cond do
+      is_nil(event.start_at) ->
+        {:error, "Missing start_at"}
+        
+      event.ends_at && DateTime.compare(event.start_at, event.ends_at) == :gt ->
+        {:error, "Event ends before it starts"}
+        
+      DateTime.compare(event.start_at, DateTime.utc_now()) == :lt ->
+        # Past events are okay for seed data
+        {:ok, "Past event (seed data)"}
+        
+      true ->
+        {:ok, "Valid datetime"}
+    end
+  end
+  
+  defp check_status_validity(event) do
+    valid_statuses = ["draft", "polling", "threshold", "confirmed", "canceled"]
+    
+    if Enum.member?(valid_statuses, event.status) do
+      {:ok, "Valid status"}
+    else
+      {:error, "Invalid status: #{event.status}. Valid: #{Enum.join(valid_statuses, ", ")}"}
+    end
+  end
+  
+  # Auto-fix functions
+  
+  defp apply_fixes_to_event(event, fix_types) do
+    fixes = []
+    
+    fixes = if :images in fix_types do
+      case ImageService.validate_event_image(event) do
+        {:ok, _} -> fixes
+        {:error, _} -> [fix_event_image(event) | fixes]
+      end
+    else
+      fixes
+    end
+    
+    fixes = if :venues in fix_types do
+      case VenueService.validate_event_venue(event) do
+        {:ok, _} -> fixes
+        {:error, _} -> [fix_event_venue(event) | fixes]
+      end
+    else
+      fixes
+    end
+    
+    # Filter out nil fixes
+    Enum.reject(fixes, &is_nil/1)
+  end
+  
+  defp fix_event_image(event) do
+    # Determine event type for appropriate image
+    event_type = guess_event_type_from_title(event.title)
+    image_attrs = ImageService.get_image_attributes(event_type)
+    
+    changeset = Ecto.Changeset.change(event, image_attrs)
+    
+    case Repo.update(changeset) do
+      {:ok, _updated_event} ->
+        "Fixed image for event #{event.id} (#{event.title})"
+      {:error, _} ->
+        nil
+    end
+  end
+  
+  defp fix_event_venue(event) do
+    # If event is missing venue but not marked as virtual, try to add venue
+    if is_nil(event.venue_id) and not event.is_virtual do
+      event_type = guess_event_type_from_title(event.title)
+      
+      # For simplicity, mark as virtual rather than creating venues
+      changeset = Ecto.Changeset.change(event, %{
+        is_virtual: true,
+        virtual_venue_url: "https://meet.google.com/virtual-event"
+      })
+      
+      case Repo.update(changeset) do
+        {:ok, _updated_event} ->
+          "Converted event #{event.id} to virtual (#{event.title})"
+        {:error, _} ->
+          nil
+      end
+    else
+      nil
+    end
+  end
+  
+  # Helper to guess event type from title for fixes
+  defp guess_event_type_from_title(title) do
+    title_lower = String.downcase(title)
+    
+    cond do
+      String.contains?(title_lower, ["conference", "tech", "summit"]) -> :conference
+      String.contains?(title_lower, ["wedding", "bride", "groom"]) -> :wedding
+      String.contains?(title_lower, ["workshop", "training", "class"]) -> :workshop
+      String.contains?(title_lower, ["meetup", "gathering", "social"]) -> :meetup
+      String.contains?(title_lower, ["party", "celebration", "birthday"]) -> :party
+      String.contains?(title_lower, ["festival", "arts", "music"]) -> :festival
+      String.contains?(title_lower, ["seminar", "presentation", "talk"]) -> :seminar
+      String.contains?(title_lower, ["retreat", "wellness", "spa"]) -> :retreat
+      String.contains?(title_lower, ["network", "business", "corporate"]) -> :networking
+      String.contains?(title_lower, ["launch", "startup", "product"]) -> :launch
+      true -> :general
+    end
+  end
+  
+  # Suggestion functions
+  
+  defp suggest_fixes(issues) do
+    if Enum.any?(issues, &String.contains?(&1, "missing cover_image_url")) do
+      Helpers.log("  • Run DevSeeds.Validator.auto_fix_issues([:images]) to fix missing images")
+    end
+    
+    if Enum.any?(issues, &String.contains?(&1, "venue")) do
+      Helpers.log("  • Run DevSeeds.Validator.auto_fix_issues([:venues]) to fix venue issues")
+    end
+    
+    if Enum.any?(issues, &String.contains?(&1, "status")) do
+      Helpers.log("  • Check event status values against valid enum values")
+    end
+  end
+  
+  @doc """
+  Quick validation check - returns true if all events pass validation.
+  """
+  def all_events_valid?() do
+    case validate_all_events() do
+      {:ok, _} -> true
+      {:error, _} -> false
+    end
+  end
+end

--- a/priv/repo/dev_seeds/services/venue_service.ex
+++ b/priv/repo/dev_seeds/services/venue_service.ex
@@ -1,0 +1,239 @@
+defmodule DevSeeds.VenueService do
+  @moduledoc """
+  Centralized service for handling event venue assignment and virtual/physical logic.
+  
+  This service ensures consistent venue assignment across all seed modules,
+  properly handling both physical venues and virtual events.
+  """
+  
+  import EventasaurusApp.Factory
+  alias EventasaurusApp.Repo
+  alias EventasaurusApp.Venues.Venue
+  
+  @doc """
+  Gets venue attributes for an event based on its type and options.
+  
+  ## Parameters
+  - event_type: atom representing the event type (:conference, :wedding, etc.)
+  - options: keyword list of options
+    - virtual: boolean to force virtual event (default: false)  
+    - venue_type: override default venue type for event type
+    - location: specific location/city for venue selection
+    
+  ## Returns
+  Map with venue-related attributes (venue_id, is_virtual, virtual_venue_url, etc.)
+  
+  ## Examples
+  
+      # Create physical conference venue
+      attrs = DevSeeds.VenueService.get_venue_attributes(:conference)
+      # => %{venue_id: 123, is_virtual: false}
+      
+      # Force virtual event
+      attrs = DevSeeds.VenueService.get_venue_attributes(:wedding, virtual: true)
+      # => %{venue_id: nil, is_virtual: true, virtual_venue_url: "https://zoom.us/..."}
+  """
+  def get_venue_attributes(event_type, options \\ []) do
+    virtual = Keyword.get(options, :virtual, false)
+    
+    if virtual or should_be_virtual?(event_type) do
+      get_virtual_venue_attributes(event_type)
+    else
+      get_physical_venue_attributes(event_type, options)
+    end
+  end
+  
+  @doc """
+  Gets or creates a venue appropriate for the event type.
+  
+  ## Parameters
+  - event_type: atom representing the event type
+  - options: keyword list of options
+    - location: preferred location/city
+    - venue_type: specific venue type override
+    - capacity: minimum venue capacity needed
+    
+  ## Returns
+  Venue struct that can be used for venue_id assignment
+  """
+  def get_or_create_venue(event_type, options \\ []) do
+    venue_type = Keyword.get(options, :venue_type) || get_default_venue_type(event_type)
+    capacity = Keyword.get(options, :capacity, get_default_capacity(event_type))
+    
+    # Try to find existing suitable venue first
+    case find_suitable_venue(venue_type, capacity) do
+      nil ->
+        create_venue_for_type(venue_type, capacity, options)
+      venue ->
+        venue
+    end
+  end
+  
+  @doc """
+  Validates that an event has proper venue configuration.
+  
+  ## Parameters
+  - event: event struct or map
+  
+  ## Returns
+  - {:ok, event} if venue configuration is valid
+  - {:error, reason} if venue configuration is invalid
+  """
+  def validate_event_venue(event) do
+    is_virtual = Map.get(event, :is_virtual, false)
+    venue_id = Map.get(event, :venue_id)
+    virtual_venue_url = Map.get(event, :virtual_venue_url)
+    
+    cond do
+      is_virtual and not is_nil(venue_id) ->
+        {:error, "Virtual event should not have venue_id"}
+        
+      is_virtual and is_nil(virtual_venue_url) ->
+        {:error, "Virtual event missing virtual_venue_url"}
+        
+      not is_virtual and is_nil(venue_id) ->
+        {:error, "Physical event missing venue_id"}
+        
+      true ->
+        {:ok, event}
+    end
+  end
+  
+  # Private functions
+  
+  # Determines if an event type should default to virtual
+  defp should_be_virtual?(:webinar), do: true
+  defp should_be_virtual?(:online_course), do: true
+  defp should_be_virtual?(_), do: false
+  
+  # Gets virtual venue attributes for an event
+  defp get_virtual_venue_attributes(_event_type) do
+    %{
+      venue_id: nil,
+      is_virtual: true,
+      virtual_venue_url: generate_virtual_venue_url()
+    }
+  end
+  
+  # Gets physical venue attributes for an event
+  defp get_physical_venue_attributes(event_type, options) do
+    venue = get_or_create_venue(event_type, options)
+    
+    %{
+      venue_id: venue.id,
+      is_virtual: false,
+      virtual_venue_url: nil
+    }
+  end
+  
+  # Maps event types to appropriate venue types
+  defp get_default_venue_type(:conference), do: "convention_center"
+  defp get_default_venue_type(:wedding), do: "event_hall"
+  defp get_default_venue_type(:workshop), do: "classroom"
+  defp get_default_venue_type(:meetup), do: "cafe"
+  defp get_default_venue_type(:party), do: "event_hall"
+  defp get_default_venue_type(:festival), do: "outdoor_venue"
+  defp get_default_venue_type(:seminar), do: "conference_room"
+  defp get_default_venue_type(:retreat), do: "resort"
+  defp get_default_venue_type(:networking), do: "business_center"
+  defp get_default_venue_type(:launch), do: "event_space"
+  defp get_default_venue_type(_), do: "event_space"
+  
+  # Gets default capacity for event types
+  defp get_default_capacity(:conference), do: 200
+  defp get_default_capacity(:wedding), do: 150
+  defp get_default_capacity(:workshop), do: 30
+  defp get_default_capacity(:meetup), do: 50
+  defp get_default_capacity(:party), do: 100
+  defp get_default_capacity(:festival), do: 500
+  defp get_default_capacity(:seminar), do: 75
+  defp get_default_capacity(:retreat), do: 40
+  defp get_default_capacity(:networking), do: 80
+  defp get_default_capacity(:launch), do: 120
+  defp get_default_capacity(_), do: 100
+  
+  # Tries to find an existing venue suitable for the requirements
+  defp find_suitable_venue(venue_type, min_capacity) do
+    # Query existing venues that match our needs
+    # This is a simplified query - could be more sophisticated
+    import Ecto.Query
+    
+    from(v in Venue,
+      where: v.venue_type == ^venue_type and v.capacity >= ^min_capacity,
+      limit: 1
+    )
+    |> Repo.one()
+  end
+  
+  # Creates a new venue for the specified type and capacity
+  defp create_venue_for_type(venue_type, capacity, options) do
+    location = Keyword.get(options, :location, get_default_location())
+    
+    venue_attrs = %{
+      name: generate_venue_name(venue_type),
+      venue_type: venue_type,
+      capacity: capacity,
+      address: generate_venue_address(location),
+      city: location,
+      state: "CA", # Default to California for seed data
+      country: "US",
+      description: generate_venue_description(venue_type)
+    }
+    
+    insert(:venue, venue_attrs)
+  end
+  
+  # Generates realistic venue names based on type
+  defp generate_venue_name("convention_center"), do: Faker.Company.name() <> " Convention Center"
+  defp generate_venue_name("event_hall"), do: Faker.Address.street_name() <> " Event Hall"
+  defp generate_venue_name("classroom"), do: Faker.Company.name() <> " Learning Center"
+  defp generate_venue_name("cafe"), do: Faker.Food.dish() <> " Cafe"
+  defp generate_venue_name("outdoor_venue"), do: Faker.Address.street_name() <> " Park"
+  defp generate_venue_name("conference_room"), do: Faker.Company.name() <> " Conference Center"
+  defp generate_venue_name("resort"), do: Faker.Address.street_name() <> " Resort"
+  defp generate_venue_name("business_center"), do: Faker.Company.name() <> " Business Center"
+  defp generate_venue_name("event_space"), do: Faker.Address.street_name() <> " Event Space"
+  defp generate_venue_name(_), do: Faker.Company.name() <> " Venue"
+  
+  # Generates venue addresses
+  defp generate_venue_address(city) do
+    "#{Faker.Address.street_address()}, #{city}"
+  end
+  
+  # Generates venue descriptions
+  defp generate_venue_description(venue_type) do
+    base_descriptions = %{
+      "convention_center" => "Modern convention center with state-of-the-art facilities",
+      "event_hall" => "Elegant event hall perfect for celebrations and gatherings",
+      "classroom" => "Interactive learning space with modern teaching facilities",
+      "cafe" => "Cozy cafe atmosphere perfect for casual meetings",
+      "outdoor_venue" => "Beautiful outdoor space with natural surroundings",
+      "conference_room" => "Professional conference facilities with latest technology",
+      "resort" => "Luxury resort venue with comprehensive amenities",
+      "business_center" => "Professional business environment for corporate events",
+      "event_space" => "Versatile event space suitable for various occasions"
+    }
+    
+    Map.get(base_descriptions, venue_type, "Professional event venue")
+  end
+  
+  # Gets default location for venue creation
+  defp get_default_location() do
+    locations = ["San Francisco", "Los Angeles", "San Diego", "Sacramento", "Oakland"]
+    Enum.random(locations)
+  end
+  
+  # Generates virtual venue URLs
+  defp generate_virtual_venue_url() do
+    platforms = ["zoom.us", "meet.google.com", "teams.microsoft.com", "webex.com"]
+    platform = Enum.random(platforms)
+    room_id = :crypto.strong_rand_bytes(8) |> Base.encode64() |> String.slice(0, 10)
+    
+    case platform do
+      "zoom.us" -> "https://zoom.us/j/#{:rand.uniform(999999999)}"
+      "meet.google.com" -> "https://meet.google.com/#{room_id}"
+      "teams.microsoft.com" -> "https://teams.microsoft.com/l/meetup-join/#{room_id}"
+      "webex.com" -> "https://#{room_id}.webex.com/join"
+    end
+  end
+end


### PR DESCRIPTION
### TL;DR

Added comprehensive polling scenarios for development and testing environments.

### What changed?

Added a new seed file `enhanced_variety_polls.exs` that creates diverse polling scenarios across different event types. The implementation includes:

- Five different event types (tech conference, wedding planning, startup launch, community festival, corporate retreat)
- Three polls per event with varying configurations
- Different poll states (active, completed, draft)
- Various privacy settings (public, private, members-only)
- Different voting systems (binary, ranked, approval, star rating)

Also updated the `runner.exs` file to include this new seed module in the development seeding process.

### How to test?

1. Run the development seed script:
   ```
   mix run priv/repo/dev_seeds/runner.exs
   ```

2. Log into the application and verify the new events are created with their associated polls:
   - "Annual Tech Conference 2025"
   - "Sarah & Mike's Wedding Planning"
   - "TechStartup Launch Event"
   - "Annual Community Arts Festival"
   - "Q4 Corporate Team Retreat"

3. Check that each event has 3 polls with different configurations and states.

### Why make this change?

This enhances the development environment with more realistic and diverse polling scenarios, making it easier to test and develop poll-related features. The variety of configurations (different privacy settings, voting systems, and poll states) provides a more comprehensive testing environment that better represents real-world usage patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces rich demo data for Phase IV: five diverse events, each with three polls (varying phases and privacy), multiple options, and realistic participant counts.
  - Covers scenarios like conferences, weddings, launches, festivals, and retreats to showcase varied polling use cases.

- Chores
  - Updates the development seed runner to include the new Enhanced Variety Polls step, with safeguards to load and execute the seed only when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->