### PR TITLE
small

### DIFF
--- a/lib/eventasaurus_web/controllers/profile_controller.ex
+++ b/lib/eventasaurus_web/controllers/profile_controller.ex
@@ -30,13 +30,20 @@ defmodule EventasaurusWeb.ProfileController do
             # Public profile - show the profile page
             auth_user = conn.assigns[:auth_user]
             
+            # Ensure we have a proper User struct for mutual events query
+            viewer_user = case auth_user do
+              %User{} = u -> u
+              %{id: id} when is_integer(id) -> Accounts.get_user(id)
+              _ -> nil
+            end
+            
             # Get profile data
             stats = Accounts.get_user_event_stats(user)
             recent_events = Accounts.get_user_recent_events(user, limit: 10)
             
-            # Get mutual events if user is logged in
-            mutual_events = if auth_user && auth_user.id != user.id do
-              Accounts.get_mutual_events(auth_user, user, limit: 6)
+            # Get mutual events if user is logged in and different from profile user
+            mutual_events = if viewer_user && viewer_user.id != user.id do
+              Accounts.get_mutual_events(viewer_user, user, limit: 6)
             else
               []
             end

--- a/lib/eventasaurus_web/controllers/profile_html/show.html.heex
+++ b/lib/eventasaurus_web/controllers/profile_html/show.html.heex
@@ -93,7 +93,7 @@
       <!-- Main Content -->
       <div class="lg:col-span-2 space-y-8">
         <!-- Mutual Events Section (only show if there are mutual events) -->
-        <%= if length(@mutual_events) > 0 do %>
+        <%= if match?([_|_], @mutual_events) do %>
           <div class="bg-white shadow-sm rounded-lg overflow-hidden">
             <div class="px-6 py-4 border-b border-gray-200">
               <h2 class="text-lg font-semibold text-gray-900">Mutual Events</h2>
@@ -128,14 +128,14 @@
             <h2 class="text-lg font-semibold text-gray-900">
               <%= if assigns[:is_own_profile], do: "Your Events", else: "Recent Events" %>
             </h2>
-            <%= if length(@recent_events) > 6 do %>
+            <%= if Enum.count(@recent_events || []) > 6 do %>
               <button class="text-sm text-blue-600 hover:text-blue-800 font-medium">View All</button>
             <% end %>
           </div>
           
-          <%= if length(@recent_events) > 0 do %>
+          <%= if match?([_|_], @recent_events) do %>
             <div class="divide-y divide-gray-200">
-              <%= for event <- Enum.take(@recent_events, 6) do %>
+              <%= for event <- Enum.take(@recent_events || [], 6) do %>
                 <div class="p-6 hover:bg-gray-50 transition-colors">
                   <.link href={~p"/#{event.slug}"} class="flex items-start space-x-4 group">
                     <div class="flex-shrink-0">


### PR DESCRIPTION
### TL;DR

Fixed duplicate events in user profiles and improved mutual events display.

### What changed?

- Modified the event query in `accounts.ex` to use `union_all` instead of `union` and added `distinct: e.id` to properly handle duplicate events
- Added logic to prefer the organizer role when a user has multiple roles for the same event
- Improved the handling of mutual events in the profile controller by ensuring we have a proper User struct
- Enhanced the profile template with more robust checks for empty event lists using `match?([_|_], @mutual_events)` instead of `length()` checks

### How to test?

1. Log in as a user who is both an organizer and attendee for the same event
2. Visit their profile page and verify that the event appears only once
3. Visit another user's profile with whom you share events and verify mutual events display correctly
4. Test with users who have no mutual events to ensure the section doesn't appear

### Why make this change?

Users who were both organizers and attendees for the same event were seeing duplicate entries in their profile. This change ensures events appear only once while prioritizing the organizer role. Additionally, the mutual events section was causing errors in some cases due to improper user struct handling, which is now fixed with more robust checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Recent events now show correctly without duplicates, sorted by start date, preferring the organizer view when applicable.
  - Mutual events display reliably based on the signed-in viewer and are hidden when not applicable.
  - Profile page no longer errors when events data is missing; lists render safely and “View All” appears only when enough items exist.
- Refactor
  - Improved internal logic for retrieving recent and mutual events to ensure consistent, accurate results while maintaining existing limits and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->