### PR TITLE
small changes

### DIFF
--- a/lib/eventasaurus_web/live/components/event_poll_integration_component.ex
+++ b/lib/eventasaurus_web/live/components/event_poll_integration_component.ex
@@ -1892,11 +1892,10 @@ defmodule EventasaurusWeb.EventPollIntegrationComponent do
     # User can manage poll if they are:
     # 1. The poll creator
     # 2. An event organizer
-    # 3. The event creator
+    # 3. An event organizer
     cond do
       is_nil(user) -> false
       poll.created_by_id == user.id -> true
-      event.user_id == user.id -> true
       Events.user_is_organizer?(event, user) -> true
       true -> false
     end

--- a/lib/eventasaurus_web/live/components/participant_status_display_component.ex
+++ b/lib/eventasaurus_web/live/components/participant_status_display_component.ex
@@ -77,6 +77,8 @@ defmodule EventasaurusWeb.ParticipantStatusDisplayComponent do
                 phx-click="toggle_expanded"
                 phx-target={@myself}
                 class="text-sm text-blue-600 hover:text-blue-800 font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-md px-2 py-1"
+                aria-expanded={@show_expanded}
+                aria-controls={"breakdown-#{@id}"}
               >
                 <%= if @show_expanded, do: "Hide details", else: "Show details" %>
               </button>
@@ -85,7 +87,7 @@ defmodule EventasaurusWeb.ParticipantStatusDisplayComponent do
 
           <!-- Expanded status breakdown -->
           <%= if @show_expanded && @has_breakdown do %>
-            <div class="expanded-breakdown border-t border-gray-200 pt-4 space-y-3">
+            <div id={"breakdown-#{@id}"} class="expanded-breakdown border-t border-gray-200 pt-4 space-y-3">
               <%= for {status, group} <- @participant_groups do %>
                 <.status_section
                   status={status}
@@ -152,7 +154,7 @@ defmodule EventasaurusWeb.ParticipantStatusDisplayComponent do
           ]}
           role="img"
           aria-label={get_participant_name(participant)}
-          aria-describedby={"tooltip-#{participant.id}"}
+          aria-describedby={"tooltip-unified-#{participant.id}"}
           tabindex="0"
           style={"z-index: #{@max_avatars - index}"}
         >
@@ -166,8 +168,7 @@ defmodule EventasaurusWeb.ParticipantStatusDisplayComponent do
           <!-- Tooltip on hover -->
           <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-white text-gray-900 text-xs rounded-md shadow-lg border border-gray-200 opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50"
                role="tooltip"
-               id={"tooltip-#{participant.id}"}
-               aria-hidden="true">
+               id={"tooltip-unified-#{participant.id}"}>
             <%= get_participant_name(participant) %>
             <div class="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-white"></div>
           </div>
@@ -201,7 +202,7 @@ defmodule EventasaurusWeb.ParticipantStatusDisplayComponent do
           ]}
           role="img"
           aria-label={get_participant_name(participant)}
-          aria-describedby={"tooltip-#{participant.id}"}
+          aria-describedby={"tooltip-breakdown-#{@status}-#{participant.id}"}
           tabindex="0"
           style={"z-index: #{@max_avatars - index}"}
         >
@@ -215,8 +216,7 @@ defmodule EventasaurusWeb.ParticipantStatusDisplayComponent do
           <!-- Tooltip on hover -->
           <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-white text-gray-900 text-xs rounded-md shadow-lg border border-gray-200 opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50"
                role="tooltip"
-               id={"tooltip-#{participant.id}"}
-               aria-hidden="true">
+               id={"tooltip-breakdown-#{@status}-#{participant.id}"}>
             <%= get_participant_name(participant) %>
             <div class="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-white"></div>
           </div>


### PR DESCRIPTION
### TL;DR

Fixed poll management permissions and improved accessibility for participant status components.

### What changed?

- Removed redundant permission check in `can_manage_poll?` function - event creators were being checked twice (once directly and once via the organizer check)
- Added proper ARIA attributes to the participant status display component:
  - Added `aria-expanded` and `aria-controls` attributes to the "Show/Hide details" button
  - Added unique ID to the expandable breakdown section
  - Fixed tooltip IDs to ensure they're unique across different sections
  - Removed unnecessary `aria-hidden="true"` from tooltips

### How to test?

1. Verify poll management permissions work correctly:
   - Confirm poll creators can manage polls
   - Confirm event organizers can manage polls
   - Verify there are no regressions in permission handling

2. Test accessibility improvements:
   - Use a screen reader to verify the "Show/Hide details" button properly announces its expanded state
   - Verify tooltips appear correctly when hovering over participant avatars
   - Check that keyboard navigation works properly with the improved ARIA attributes

### Why make this change?

The permission check had a redundant condition since event creators are already included in the organizer check. The accessibility improvements make the participant status component more usable for people using assistive technologies by providing proper ARIA attributes and ensuring unique IDs for related elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Tightened poll management permissions: event creators no longer automatically manage polls; only poll creators or event organizers can manage polls.

- Accessibility
  - Improved participant status display for assistive technologies: added aria-expanded and aria-controls with unique IDs, standardized tooltip IDs, removed aria-hidden from tooltips, and updated aria-describedby on avatars to correctly reference tooltips and breakdown panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->