### PR TITLE
groups

### DIFF
--- a/lib/eventasaurus_web/live/components/participant_status_display_component.ex
+++ b/lib/eventasaurus_web/live/components/participant_status_display_component.ex
@@ -84,6 +84,7 @@ defmodule EventasaurusWeb.ParticipantStatusDisplayComponent do
                   participants={@display_participants}
                   max_avatars={@max_avatars}
                   avatar_size={@avatar_size}
+                  id={@id}
                 />
               </div>
             <% end %>
@@ -99,6 +100,7 @@ defmodule EventasaurusWeb.ParticipantStatusDisplayComponent do
                   avatar_size={:sm}
                   max_avatars={5}
                   show_avatars={true}
+                  id={@id}
                 />
               <% end %>
             </div>
@@ -140,6 +142,7 @@ defmodule EventasaurusWeb.ParticipantStatusDisplayComponent do
             max_avatars={@max_avatars}
             avatar_size={@avatar_size}
             status={@status}
+            id={@id}
           />
         </div>
       <% end %>

--- a/lib/eventasaurus_web/live/components/presented_by_component.ex
+++ b/lib/eventasaurus_web/live/components/presented_by_component.ex
@@ -1,0 +1,51 @@
+defmodule EventasaurusWeb.PresentedByComponent do
+  @moduledoc """
+  Component that displays "Presented by" information when an event belongs to a group.
+  Shows group icon, name, and provides a clickable link to the group page.
+  """
+
+  use EventasaurusWeb, :live_component
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <div :if={@group} class="bg-white border border-gray-200 rounded-xl p-4 shadow-sm mb-6">
+        <div class="flex items-center justify-between">
+          <span class="text-xs text-gray-500 font-medium uppercase tracking-wide">Presented by</span>
+        </div>
+        
+        <.link 
+          navigate={~p"/groups/#{@group.slug}"} 
+          class="flex items-center space-x-3 mt-2 hover:bg-gray-50 p-2 rounded-lg transition-colors group"
+        >
+          <div class="flex-shrink-0">
+            <img 
+              :if={@group.avatar_url}
+              src={@group.avatar_url} 
+              alt={"#{@group.name} avatar"}
+              class="w-8 h-8 rounded-full object-cover border border-gray-200"
+            />
+            <div 
+              :if={!@group.avatar_url}
+              class="w-8 h-8 rounded-full bg-gradient-to-br from-purple-400 to-pink-400 flex items-center justify-center text-white text-sm font-semibold"
+            >
+              <%= String.first(@group.name) |> String.upcase() %>
+            </div>
+          </div>
+          
+          <div class="flex-1">
+            <span class="text-sm font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+              <%= @group.name %>
+            </span>
+          </div>
+          
+          <svg class="w-4 h-4 text-gray-400 group-hover:text-blue-600 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </.link>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -6,12 +6,14 @@ defmodule EventasaurusWeb.PublicEventLive do
   require Logger
 
   alias EventasaurusApp.Events
+  alias EventasaurusApp.Groups
   alias EventasaurusApp.Venues
   alias EventasaurusApp.Accounts
   alias EventasaurusApp.Ticketing
   alias EventasaurusWeb.EventRegistrationComponent
   alias EventasaurusWeb.AnonymousVoterComponent
   alias EventasaurusWeb.PublicGenericPollComponent
+  alias EventasaurusWeb.PresentedByComponent
 
   alias EventasaurusWeb.ReservedSlugs
 
@@ -44,6 +46,10 @@ defmodule EventasaurusWeb.PublicEventLive do
         event ->
           # Load venue if needed
           venue = if event.venue_id, do: Venues.get_venue(event.venue_id), else: nil
+          
+          # Load group if event belongs to one
+          group = if event.group_id, do: Groups.get_group(event.group_id), else: nil
+          
           organizers = Events.list_event_organizers(event)
 
           # Load participants for social proof
@@ -121,6 +127,7 @@ defmodule EventasaurusWeb.PublicEventLive do
            socket
            |> assign(:event, event)
            |> assign(:venue, venue)
+           |> assign(:group, group)
            |> assign(:organizers, organizers)
            |> assign(:participants, participants)
            |> assign(:registration_status, registration_status)
@@ -1502,6 +1509,15 @@ defmodule EventasaurusWeb.PublicEventLive do
               event={@event}
               user={@user}
               loading={@ticket_loading}
+            />
+          <% end %>
+
+          <!-- Presented By Section (when event belongs to a group) -->
+          <%= if @group do %>
+            <.live_component
+              module={PresentedByComponent}
+              id="presented-by"
+              group={@group}
             />
           <% end %>
 


### PR DESCRIPTION
### TL;DR

Added a new "Presented by" component to display group information on event pages.

### What changed?

- Created a new `PresentedByComponent` that shows group information (icon, name, and link) when an event belongs to a group
- Added the component to the `PublicEventLive` view
- Updated the `participant_status_display_component.ex` to pass the `id` prop to child components
- Modified `PublicEventLive` to load group data when an event belongs to a group

### How to test?

1. Create or edit an event to associate it with a group
2. View the public event page
3. Verify the "Presented by" section appears with the correct group information
4. Click on the group link to ensure it navigates to the group page
5. Check that the group avatar (or first letter if no avatar) displays correctly

### Why make this change?

This change improves event discoverability by clearly showing group affiliations on event pages. It helps attendees understand who is organizing the event and provides a way to explore other events from the same group, enhancing the overall user experience and creating better connections between related content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a “Presented by” card on event pages when an event is associated with a group. Displays the group’s avatar or a styled initial, the group name, and a link to the group page. Shown in the main content and the sidebar.

* Bug Fixes
  * Improved participant status tooltips and containers by ensuring unique identifiers across nested UI elements, preventing collisions and enhancing accessibility and interaction consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->