### PR TITLE
tiny

### DIFF
--- a/lib/eventasaurus_web/live/components/presented_by_component.ex
+++ b/lib/eventasaurus_web/live/components/presented_by_component.ex
@@ -30,7 +30,14 @@ defmodule EventasaurusWeb.PresentedByComponent do
               :if={!@group.avatar_url}
               class="w-8 h-8 rounded-full bg-gradient-to-br from-purple-400 to-pink-400 flex items-center justify-center text-white text-sm font-semibold"
             >
-              <%= String.first(@group.name) |> String.upcase() %>
+              <%= case @group do
+                    %{name: name} when is_binary(name) and name != "" ->
+                      name |> String.first() |> String.upcase()
+                    %{slug: slug} when is_binary(slug) and slug != "" ->
+                      slug |> String.first() |> String.upcase()
+                    _ ->
+                      "?"
+                  end %>
             </div>
           </div>
           


### PR DESCRIPTION
### TL;DR

Fixed the avatar fallback logic in the PresentedByComponent to handle edge cases.

### What changed?

Enhanced the avatar fallback logic in the PresentedByComponent to handle cases where the group name might be empty or nil. The component now:
- First tries to use the first letter of the group name if it exists
- Falls back to the first letter of the slug if name is unavailable
- Displays a "?" character if neither name nor slug is available

### How to test?

1. View events with groups that have:
   - Normal names
   - Empty names but valid slugs
   - Neither valid names nor slugs
2. Verify that the avatar fallback displays correctly in each case:
   - First letter of name (uppercase)
   - First letter of slug (uppercase)
   - "?" character for edge cases

### Why make this change?

This change prevents potential errors when displaying group avatars in cases where the group data might be incomplete. It provides a more robust fallback mechanism that gracefully handles edge cases, improving the overall user experience and application stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added slug-based fallback for group avatar placeholders when no image is provided.
* **Bug Fixes**
  * Improved avatar placeholder logic to handle missing or empty group names. The initial now derives from the name; if unavailable, it falls back to the slug; if both are missing, a “?” is shown. This prevents blank or incorrect placeholders and ensures consistent display across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->