### PR TITLE
align

### DIFF
--- a/lib/eventasaurus_web/live/public_event_live.ex
+++ b/lib/eventasaurus_web/live/public_event_live.ex
@@ -1512,14 +1512,6 @@ defmodule EventasaurusWeb.PublicEventLive do
             />
           <% end %>
 
-          <!-- Presented By Section (when event belongs to a group) -->
-          <%= if @group do %>
-            <.live_component
-              module={PresentedByComponent}
-              id="presented-by"
-              group={@group}
-            />
-          <% end %>
 
                      <!-- Registration Card -->
            <div class="mobile-register-card bg-white border border-gray-200 rounded-xl p-6 shadow-sm mb-6">
@@ -1712,6 +1704,15 @@ defmodule EventasaurusWeb.PublicEventLive do
                </svg>
              </button>
            </div>
+
+          <!-- Presented by -->
+          <%= if @group do %>
+            <.live_component
+              module={PresentedByComponent}
+              id="presented-by"
+              group={@group}
+            />
+          <% end %>
 
                      <!-- Combined Share & Calendar Section -->
            <div id="mobile-secondary-actions" class="mobile-secondary-actions bg-white border border-gray-200 rounded-xl p-5 shadow-sm">


### PR DESCRIPTION
### TL;DR

Moved the "Presented By" section below the registration card on the public event page.

### What changed?

Relocated the "Presented By" component (which shows when an event belongs to a group) from its previous position above the registration card to a new position below the registration card but above the "Share & Calendar" section.

### How to test?

1. Navigate to a public event page that belongs to a group
2. Verify that the "Presented By" section now appears below the registration card
3. Confirm that the section still displays correctly in its new position
4. Check that the mobile view renders properly with this new arrangement

### Why make this change?

This change improves the visual hierarchy of the page by prioritizing the registration card, which is the primary call-to-action for users. Moving the "Presented By" section lower on the page maintains its visibility while ensuring the registration options are immediately available to users when they view an event.