### PR TITLE
update to bulk

### DIFF
--- a/lib/eventasaurus_web/components/individual_email_input.ex
+++ b/lib/eventasaurus_web/components/individual_email_input.ex
@@ -109,13 +109,15 @@ defmodule EventasaurusWeb.Components.IndividualEmailInput do
           </summary>
           
           <div class="mt-3 space-y-2">
-            <textarea
-              id={"#{@id}-bulk-input"}
-              rows="3"
-              placeholder="Paste multiple emails separated by commas or new lines:&#10;user1@example.com, user2@example.com&#10;user3@example.com"
-              class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-              phx-change="bulk_email_input"
-            ></textarea>
+            <form phx-change="bulk_email_input">
+              <textarea
+                id={"#{@id}-bulk-input"}
+                name="bulk_email_input"
+                rows="3"
+                placeholder="Paste multiple emails separated by commas or new lines:&#10;user1@example.com, user2@example.com&#10;user3@example.com"
+                class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+              ></textarea>
+            </form>
             
             <button
               type="button"

--- a/lib/eventasaurus_web/live/event_manage_live.ex
+++ b/lib/eventasaurus_web/live/event_manage_live.ex
@@ -307,7 +307,7 @@ defmodule EventasaurusWeb.EventManageLive do
   end
 
   @impl true
-  def handle_event("bulk_email_input", %{"value" => bulk_input}, socket) do
+  def handle_event("bulk_email_input", %{"bulk_email_input" => bulk_input}, socket) do
     {:noreply, assign(socket, :bulk_email_input, bulk_input)}
   end
 


### PR DESCRIPTION
### TL;DR

Fixed the bulk email input functionality by properly wrapping the textarea in a form element and updating the event handler parameter structure.

### What changed?

- Wrapped the textarea in a `<form>` element with the `phx-change="bulk_email_input"` directive
- Added a `name="bulk_email_input"` attribute to the textarea
- Moved the `phx-change` directive from the textarea to the form element
- Updated the event handler in `event_manage_live.ex` to extract the input value from `%{"bulk_email_input" => bulk_input}` instead of `%{"value" => bulk_input}`

### How to test?

1. Navigate to an event management page
2. Open the bulk email input section
3. Paste multiple email addresses into the textarea
4. Verify that the emails are properly processed and appear in the email list

### Why make this change?

The previous implementation had an issue where the textarea's input wasn't being properly captured by the Phoenix LiveView event system. By wrapping the textarea in a form with the proper name attribute, we ensure that the input value is correctly sent to the server and processed by the event handler. This fixes the bulk email input functionality which was previously not working as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk email input now reliably captures pasted/edited content and updates in real time.
  * Live validation and processing of the bulk email field are triggered consistently, preventing missed updates.
* **UX Improvements**
  * More predictable behavior when pasting multiple emails; no visual or styling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->