### PR TITLE
last change

### DIFF
--- a/lib/eventasaurus_app/venues/venue.ex
+++ b/lib/eventasaurus_app/venues/venue.ex
@@ -56,8 +56,6 @@ defmodule EventasaurusApp.Venues.Venue do
     |> validate_place_id_source()
     |> Slug.maybe_generate_slug()
     |> unique_constraint(:slug)
-    |> unique_constraint([:normalized_name, :city_id])
-    |> unique_constraint(:place_id)
     |> foreign_key_constraint(:city_id)
   end
 

--- a/lib/eventasaurus_discovery/scraping/scrapers/bandsintown/jobs/event_detail_job.ex
+++ b/lib/eventasaurus_discovery/scraping/scrapers/bandsintown/jobs/event_detail_job.ex
@@ -253,8 +253,8 @@ defmodule EventasaurusDiscovery.Scraping.Scrapers.Bandsintown.Jobs.EventDetailJo
       |> PublicEventSource.changeset(attrs)
 
     Repo.insert(changeset,
-      on_conflict: {:replace, [:source_url, :external_id, :last_seen_at, :metadata, :updated_at]},
-      conflict_target: [:event_id, :source_id],
+      on_conflict: {:replace, [:event_id, :source_url, :last_seen_at, :metadata, :updated_at]},
+      conflict_target: [:source_id, :external_id],
       returning: true
     )
   end

--- a/lib/eventasaurus_web/live/event_manage_live.html.heex
+++ b/lib/eventasaurus_web/live/event_manage_live.html.heex
@@ -194,7 +194,7 @@
                       <p class="text-gray-700"><%= @venue.name %></p>
                       <p class="text-gray-600 text-sm">
                         <%= @venue.address %><br>
-                        <%= @venue.city %><%= if @venue.state do %>, <%= @venue.state %><% end %>
+                        <%= EventasaurusApp.Venues.Venue.city_name(@venue) %>
                       </p>
                     </div>
                   </div>

--- a/priv/repo/migrations/20250914152008_make_source_external_id_unique.exs
+++ b/priv/repo/migrations/20250914152008_make_source_external_id_unique.exs
@@ -3,7 +3,7 @@ defmodule EventasaurusApp.Repo.Migrations.MakeSourceExternalIdUnique do
 
   def change do
     # Drop the existing non-unique index
-    drop index(:public_event_sources, [:source_id, :external_id])
+    drop_if_exists index(:public_event_sources, [:source_id, :external_id])
 
     # Create unique index to enforce per-source external_id uniqueness
     create unique_index(:public_event_sources, [:source_id, :external_id])


### PR DESCRIPTION
### TL;DR

Updated venue data handling to use city and country references instead of string fields.

### What changed?

- Modified queries in `Events` module to join with city and country tables when fetching venue information
- Updated venue data selection to use `city_ref.name` and `country.name` instead of the deprecated string fields
- Fixed conflict target in `EventDetailJob` to use `[:source_id, :external_id]` instead of `[:event_id, :source_id]`
- Removed unnecessary unique constraints from the Venue schema
- Updated the event management template to use `Venue.city_name/1` helper
- Made the migration safer by adding `drop_if_exists` for the index

### How to test?

1. Verify that events display the correct city and country information
2. Check that event listings properly show venue locations
3. Create events with venues to ensure location data is correctly saved and displayed
4. Test the BandsInTown scraper to ensure event sources are properly created/updated

### Why make this change?

This change completes the migration from storing city/country as strings to using proper references to city and country records. This provides better data consistency, enables location-based filtering, and ensures we're using the normalized data structure throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Event listings and details now show venue city and country with a consistent format.
- Performance
  - Faster event loading through a single-pass, batched retrieval of events, venues, and participants.
- Bug Fixes
  - Reduced duplicate external events by refining source deduplication logic.
- Chores
  - More resilient database index setup to prevent migration issues.
  - Standardized venue location rendering via a centralized helper for consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->