### PR TITLE
more changes

### DIFF
--- a/lib/eventasaurus_discovery/performers/performer.ex
+++ b/lib/eventasaurus_discovery/performers/performer.ex
@@ -24,7 +24,7 @@ defmodule EventasaurusDiscovery.Performers.Performer do
   @doc false
   def changeset(performer, attrs) do
     performer
-    |> cast(attrs, [:name, :image_url, :metadata, :source_id])
+    |> cast(attrs, [:name, :slug, :image_url, :metadata, :source_id])
     |> validate_required([:name])
     |> Slug.maybe_generate_slug()
     |> unique_constraint(:slug)

--- a/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
+++ b/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
@@ -265,9 +265,11 @@ defmodule EventasaurusDiscovery.Scraping.Processors.EventProcessor do
   defp create_performer(name) do
     slug = Normalizer.create_slug(name)
 
+    # Explicitly set the slug to ensure consistency
     changeset = %Performer{}
     |> Performer.changeset(%{
-      name: name
+      name: name,
+      slug: slug  # Pass slug to ensure it matches what we'll query by
     })
 
     # Handle race condition where performer might be created between check and insert


### PR DESCRIPTION
### TL;DR

Improved venue update logic and fixed performer slug consistency issues.

### What changed?

- Enhanced `update_venue_if_needed` to properly handle errors while still returning the found venue
- Expanded `should_update_venue?` to check for name changes in addition to coordinate changes
- Added `normalize_for_comparison` for name comparison in venue updates
- Modified the `Performer` changeset to explicitly include the slug field
- Updated performer creation to explicitly set the slug to ensure consistency between creation and lookup

### How to test?

1. Test venue updates with both coordinate and name changes
2. Verify that venue update errors are properly logged but don't block the process
3. Create performers with names that require slug normalization and verify they can be found by the generated slug
4. Check that performers created with the same normalized name have consistent slugs

### Why make this change?

These changes address two issues:
1. Venue updates were failing silently and only checking for coordinate changes, missing opportunities to update venue names
2. Performer slugs could be inconsistent between creation and lookup, potentially causing performers to be duplicated when they should be matched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Performers now generate consistent slugs on creation and accept provided slugs, improving deduplication and linking.
- Bug Fixes
  - Venue details reliably update when names or coordinates change.
  - Proximity-based venue updates no longer disrupt processing; failures are logged for visibility.
- Refactor
  - Streamlined venue update decision logic to reduce edge cases and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->