### PR TITLE
last updates

### DIFF
--- a/lib/eventasaurus_discovery/sources/karnet/jobs/event_detail_job.ex
+++ b/lib/eventasaurus_discovery/sources/karnet/jobs/event_detail_job.ex
@@ -47,10 +47,10 @@ defmodule EventasaurusDiscovery.Sources.Karnet.Jobs.EventDetailJob do
       {:ok, event_data} ->
         Logger.debug("📋 Extracted event data - Title: #{event_data[:title]}, Venue: #{inspect(event_data[:venue_data])}")
 
-        # Check if venue data is nil (events without venues should be rejected)
+        # Check if venue data is nil (events without venues should be discarded)
         if is_nil(event_data[:venue_data]) do
-          Logger.warning("⚠️ Rejecting event without valid venue: #{url}")
-          {:error, :no_valid_venue}
+          Logger.warning("⚠️ Discarding event without valid venue: #{url}")
+          {:discard, :no_valid_venue}
         else
           # Merge with metadata from index if available
           enriched_data = merge_metadata(event_data, metadata)


### PR DESCRIPTION
### TL;DR

Improved venue address extraction for Karnet events and changed how events without venues are handled.

### What changed?

- Enhanced the venue address extraction logic in `DetailExtractor` to more accurately find addresses by:
  - Looking for addresses specifically within the container that contains the venue link
  - Using the venue name to match the correct container
  - Maintaining the fallback extraction method when needed

- Changed how events without venues are handled in `EventDetailJob`:
  - Updated the return value from `{:error, :no_valid_venue}` to `{:discard, :no_valid_venue}`
  - Updated log message to use "discarding" instead of "rejecting" for consistency

### How to test?

1. Run the Karnet event scraper against events with different venue layouts
2. Verify that venue addresses are correctly extracted, especially for complex layouts
3. Confirm that events without venues are properly discarded with the new return value

### Why make this change?

The previous venue address extraction logic was not reliably finding the correct address when multiple venues were present on a page. This change improves accuracy by better scoping the search to the specific container that matches the venue name. Additionally, standardizing on `{:discard, :reason}` for events that should be skipped improves consistency in the job processing pipeline.