### PR TITLE
fixes for previous events

### DIFF
--- a/lib/eventasaurus_web/components/simple_email_input.ex
+++ b/lib/eventasaurus_web/components/simple_email_input.ex
@@ -28,8 +28,7 @@ defmodule EventasaurusWeb.Components.SimpleEmailInput do
             value={@current_input}
             placeholder={@placeholder}
             class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-            phx-input={@on_input_change}
-            phx-debounce="300"
+            phx-hook="EmailInput"
             phx-keydown="add_email_on_enter"
             phx-key="Enter"
           />

--- a/priv/repo/migrations/20250924211812_fix_event_plans_unique_constraint.exs
+++ b/priv/repo/migrations/20250924211812_fix_event_plans_unique_constraint.exs
@@ -1,0 +1,31 @@
+defmodule EventasaurusApp.Repo.Migrations.FixEventPlansUniqueConstraint do
+  use Ecto.Migration
+
+  def up do
+    # First, remove duplicate event_plans, keeping only the most recent one per user+public_event
+    execute """
+    DELETE FROM event_plans
+    WHERE id NOT IN (
+      SELECT DISTINCT ON (public_event_id, created_by) id
+      FROM event_plans
+      ORDER BY public_event_id, created_by, inserted_at DESC
+    )
+    """
+
+    # Drop the old incorrect unique constraint
+    drop_if_exists unique_index(:event_plans, [:public_event_id, :private_event_id, :created_by])
+
+    # Add the correct unique constraint
+    create unique_index(:event_plans, [:public_event_id, :created_by],
+      name: :unique_user_plan_per_public_event)
+  end
+
+  def down do
+    # Remove the new constraint
+    drop_if_exists unique_index(:event_plans, [:public_event_id, :created_by],
+      name: :unique_user_plan_per_public_event)
+
+    # Restore the old constraint (though it was problematic)
+    create unique_index(:event_plans, [:public_event_id, :private_event_id, :created_by])
+  end
+end


### PR DESCRIPTION
### TL;DR

Prevent duplicate event plans by adding unique constraint and showing existing plans to users.

### What changed?

- Added logic to check if a user already has a plan for a public event before creating a new one
- Modified the UI to show a "View Your Event" button instead of "Plan with Friends" when a user already has a plan
- Added a database migration to enforce a unique constraint on `public_event_id` and `created_by` in the `event_plans` table
- Improved URL parameter handling for category links
- Added safety checks for background color styles
- Replaced `phx-input` with `phx-hook="EmailInput"` in the email input component
- Added helper functions for user identification and date formatting

### How to test?

1. Create a plan for a public event
2. Return to the same public event page
3. Verify you see a "View Your Event" button instead of "Plan with Friends"
4. Click the button and confirm it redirects to your existing private event
5. Try to create a duplicate plan through other means and verify the system prevents it

### Why make this change?

Users were able to create multiple plans for the same public event, causing confusion and potential data inconsistency. This change ensures each user can only have one plan per public event, improving the user experience and data integrity. The UI now clearly shows when a user already has a plan and provides a direct way to access it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Prevents creating duplicate plans; directs you to your existing event when applicable.
  - Adds “View Your Event” button and status indicator when a plan already exists.
  - Displays friendlier plan timestamps.
  - Improves category badge color safety.
  - Smoother email input interactions.

- Bug Fixes
  - Enforces a single plan per user for each public event and cleans up past duplicates.

- Refactor
  - Streamlines plan creation and current user detection for more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->