### PR TITLE
small fix for time

### DIFF
--- a/lib/eventasaurus_web/live/public_event_show_live.ex
+++ b/lib/eventasaurus_web/live/public_event_show_live.ex
@@ -1079,8 +1079,12 @@ defmodule EventasaurusWeb.PublicEventShowLive do
   end
 
   defp event_is_past?(%{starts_at: starts_at}) when not is_nil(starts_at) do
-    # For events without end dates, consider past if it has already started
-    DateTime.compare(starts_at, DateTime.utc_now()) == :lt
+    # For events without end dates, consider them active for 24 hours after start
+    # This handles single-day events and events where end time wasn't specified
+    DateTime.compare(
+      DateTime.add(starts_at, 24, :hour),
+      DateTime.utc_now()
+    ) == :lt
   end
 
   defp event_is_past?(_), do: false


### PR DESCRIPTION
### TL;DR

Extended the active period for events without end dates from start time to 24 hours after start.

### What changed?

Modified the `event_is_past?/1` function to consider events without end dates as active for 24 hours after their start time, rather than marking them as past immediately after they start. This change adds a 24-hour buffer to single-day events or events where the end time wasn't specified.

### How to test?

1. Create an event with only a start date (no end date)
2. Verify that the event remains active for 24 hours after its start time
3. Confirm that after 24 hours have passed since the start time, the event is correctly marked as past

### Why make this change?

Previously, events without end dates were considered past immediately after they started, which wasn't ideal for user experience. Most single-day events should remain active throughout the day they occur. This 24-hour window provides a more reasonable default duration for events where organizers didn't specify an end time.