### PR TITLE
final

### DIFF
--- a/assets/js/hooks/forms.js
+++ b/assets/js/hooks/forms.js
@@ -402,12 +402,15 @@ export const EmailInput = {
   handleKeyDown(event) {
     // If Enter key is pressed, clear the input field immediately to prevent race conditions
     if (event.key === 'Enter') {
+      // Prevent default form submission on Enter
+      event.preventDefault();
+
       // Small delay to allow the Phoenix event to fire first, then clear the field
       setTimeout(() => {
         this.el.value = '';
         // Send an empty input change to sync with server
-        this.pushEvent("email_input_change", { 
-          "email_input": "" 
+        this.pushEvent("email_input_change", {
+          "email_input": ""
         });
       }, 50);
     }

--- a/lib/eventasaurus_web/components/individual_email_input.ex
+++ b/lib/eventasaurus_web/components/individual_email_input.ex
@@ -28,6 +28,8 @@ defmodule EventasaurusWeb.Components.IndividualEmailInput do
             name="email_input"
             value={@current_input}
             placeholder={@placeholder}
+            autocomplete="email"
+            inputmode="email"
             class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
             phx-input="email_input_change"
             phx-debounce="300"


### PR DESCRIPTION
### TL;DR

Fixed form submission behavior in email input component and improved email field accessibility.

### What changed?

- Added `event.preventDefault()` to the `handleKeyDown` function in the EmailInput hook to prevent default form submission when Enter key is pressed
- Added HTML attributes to the email input field:
  - `autocomplete="email"` to enable browser autocomplete functionality
  - `inputmode="email"` to display the appropriate keyboard on mobile devices

### How to test?

1. Navigate to any page with an email input field
2. Press Enter after typing an email address
3. Verify the form doesn't submit unexpectedly
4. Check that browser autocomplete works correctly for the email field
5. On mobile devices, verify that the email-specific keyboard appears

### Why make this change?

The previous implementation had a race condition where pressing Enter could trigger both the custom email handling and a form submission. This change prevents unintended form submissions while maintaining the custom email input behavior. The added HTML attributes improve user experience by enabling browser autocomplete and showing the appropriate keyboard on mobile devices.