### PR TITLE
adding geo

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -112,7 +112,9 @@ config :eventasaurus, Oban,
     # Single concurrency to respect Google's rate limits
     google_lookup: 1,
     # Default queue for other background jobs
-    default: 10
+    default: 10,
+    # Maintenance queue for background tasks like coordinate calculation
+    maintenance: 2
   ],
   plugins: [
     # Keep completed jobs for 7 days for debugging

--- a/lib/eventasaurus_discovery/jobs/city_coordinate_calculation_job.ex
+++ b/lib/eventasaurus_discovery/jobs/city_coordinate_calculation_job.ex
@@ -1,0 +1,140 @@
+defmodule EventasaurusDiscovery.Jobs.CityCoordinateCalculationJob do
+  @moduledoc """
+  Calculates city center coordinates based on the average location of all venues
+  within that city. Runs on-demand after scraping, but max once per 24 hours.
+
+  This ensures city coordinates reflect the actual center of activity rather than
+  geographic/political boundaries.
+  """
+
+  use Oban.Worker,
+    queue: :maintenance,
+    max_attempts: 3,
+    priority: 2
+
+  import Ecto.Query
+  alias EventasaurusApp.Repo
+  alias EventasaurusApp.Venues.Venue
+  alias EventasaurusDiscovery.Locations.City
+
+  require Logger
+
+  @hours_between_updates 24
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: args}) do
+    city_id = args["city_id"]
+    force = args["force"] || false
+
+    with {:ok, city} <- get_city(city_id),
+         {:ok, :should_update} <- check_update_needed(city, force),
+         {:ok, coordinates} <- calculate_coordinates(city),
+         {:ok, updated_city} <- update_city_coordinates(city, coordinates) do
+
+      Logger.info("""
+      ✅ Updated coordinates for #{updated_city.name}
+      Lat: #{Decimal.to_float(updated_city.latitude)}, Lng: #{Decimal.to_float(updated_city.longitude)}
+      Based on #{coordinates.venue_count} venues
+      """)
+
+      {:ok, %{
+        city: updated_city.name,
+        latitude: Decimal.to_float(updated_city.latitude),
+        longitude: Decimal.to_float(updated_city.longitude),
+        venue_count: coordinates.venue_count
+      }}
+    else
+      {:ok, :skip} ->
+        Logger.debug("Skipping coordinate update for city #{city_id} - recently updated")
+        {:ok, :skipped}
+
+      {:error, :no_venues} ->
+        Logger.debug("No venues with coordinates found for city #{city_id}")
+        {:ok, :no_venues}
+
+      error ->
+        Logger.error("Failed to update city coordinates: #{inspect(error)}")
+        error
+    end
+  end
+
+  defp get_city(city_id) do
+    case Repo.get(City, city_id) do
+      nil -> {:error, :city_not_found}
+      city -> {:ok, city}
+    end
+  end
+
+  defp check_update_needed(%City{updated_at: updated_at, latitude: lat, longitude: lng}, force) do
+    cond do
+      # Force flag overrides all checks
+      force ->
+        {:ok, :should_update}
+
+      # If coordinates don't exist yet, always update
+      is_nil(lat) or is_nil(lng) ->
+        {:ok, :should_update}
+
+      # Check if city was updated in the last 24 hours
+      true ->
+        hours_since_update =
+          NaiveDateTime.diff(NaiveDateTime.utc_now(), updated_at, :hour)
+
+        if hours_since_update >= @hours_between_updates do
+          {:ok, :should_update}
+        else
+          {:ok, :skip}
+        end
+    end
+  end
+
+  defp calculate_coordinates(%City{id: city_id}) do
+    # Calculate average coordinates from all venues in this city
+    # that have valid coordinates
+    query = from v in Venue,
+      where: v.city_id == ^city_id,
+      where: not is_nil(v.latitude) and not is_nil(v.longitude),
+      select: %{
+        avg_lat: fragment("AVG(CAST(? AS FLOAT))", v.latitude),
+        avg_lng: fragment("AVG(CAST(? AS FLOAT))", v.longitude),
+        count: count(v.id)
+      }
+
+    case Repo.one(query) do
+      %{avg_lat: lat, avg_lng: lng, count: count} when not is_nil(lat) and count > 0 ->
+        {:ok, %{latitude: lat, longitude: lng, venue_count: count}}
+      _ ->
+        {:error, :no_venues}
+    end
+  end
+
+  defp update_city_coordinates(%City{id: city_id}, %{latitude: lat, longitude: lng}) do
+    # Update the city coordinates using Repo.update_all for efficiency
+    {updated_count, updated_cities} =
+      from(c in City, where: c.id == ^city_id, select: c)
+      |> Repo.update_all(
+        [set: [
+          latitude: Decimal.from_float(lat),
+          longitude: Decimal.from_float(lng),
+          updated_at: NaiveDateTime.utc_now()
+        ]],
+        returning: true
+      )
+
+    if updated_count > 0 do
+      {:ok, List.first(updated_cities)}
+    else
+      {:error, :update_failed}
+    end
+  end
+
+  @doc """
+  Convenience function to schedule a coordinate update for a city.
+  Used by other modules to trigger updates.
+  """
+  def schedule_update(city_id) when is_integer(city_id) do
+    %{city_id: city_id}
+    |> __MODULE__.new()
+    |> Oban.insert()
+  end
+end

--- a/lib/mix/tasks/discovery.calculate_city_coordinates.ex
+++ b/lib/mix/tasks/discovery.calculate_city_coordinates.ex
@@ -1,0 +1,130 @@
+defmodule Mix.Tasks.Discovery.CalculateCityCoordinates do
+  @moduledoc """
+  Calculate coordinates for cities based on their venue locations.
+
+  This task calculates the average latitude and longitude of all venues
+  in each city and updates the city's coordinates accordingly.
+
+  ## Usage
+
+      # Calculate coordinates for all cities
+      mix discovery.calculate_city_coordinates
+
+      # Calculate coordinates for a specific city
+      mix discovery.calculate_city_coordinates --city-id=123
+
+      # Force recalculation even if recently updated
+      mix discovery.calculate_city_coordinates --force
+
+  ## Options
+
+    * `--city-id` - Calculate coordinates for a specific city ID
+    * `--force` - Force recalculation even if city was recently updated
+  """
+
+  use Mix.Task
+  import Ecto.Query
+  alias EventasaurusApp.Repo
+  alias EventasaurusDiscovery.Locations.City
+  alias EventasaurusDiscovery.Jobs.CityCoordinateCalculationJob
+
+  require Logger
+
+  @shortdoc "Calculate city coordinates from venue locations"
+
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    {parsed, _, _} = OptionParser.parse(args,
+      strict: [
+        city_id: :integer,
+        force: :boolean
+      ],
+      aliases: [
+        c: :city_id,
+        f: :force
+      ]
+    )
+
+    force = Keyword.get(parsed, :force, false)
+
+    case Keyword.get(parsed, :city_id) do
+      nil ->
+        calculate_all_cities(force)
+      city_id ->
+        calculate_single_city(city_id, force)
+    end
+  end
+
+  defp calculate_all_cities(force) do
+    cities = Repo.all(from c in City, select: %{id: c.id, name: c.name})
+
+    IO.puts("📍 Calculating coordinates for #{length(cities)} cities...")
+    IO.puts("")
+
+    scheduled_count = Enum.reduce(cities, 0, fn city, count ->
+      case schedule_calculation(city.id, city.name, force) do
+        :scheduled ->
+          IO.write(".")
+          count + 1
+        :skipped ->
+          IO.write("s")
+          count
+        :error ->
+          IO.write("x")
+          count
+      end
+    end)
+
+    IO.puts("")
+    IO.puts("")
+    IO.puts("✅ Scheduled coordinate calculation for #{scheduled_count} cities")
+
+    if scheduled_count < length(cities) do
+      IO.puts("ℹ️  Some cities were skipped (recently updated) or had errors")
+      IO.puts("   Use --force to recalculate all cities")
+    end
+  end
+
+  defp calculate_single_city(city_id, force) do
+    case Repo.get(City, city_id) do
+      nil ->
+        IO.puts("❌ City with ID #{city_id} not found")
+      city ->
+        IO.puts("📍 Calculating coordinates for #{city.name}...")
+
+        case schedule_calculation(city_id, city.name, force) do
+          :scheduled ->
+            IO.puts("✅ Scheduled coordinate calculation for #{city.name}")
+          :skipped ->
+            IO.puts("ℹ️  Skipped - #{city.name} was recently updated")
+            IO.puts("   Use --force to recalculate anyway")
+          :error ->
+            IO.puts("❌ Failed to schedule calculation for #{city.name}")
+        end
+    end
+  end
+
+  defp schedule_calculation(city_id, city_name, force) do
+    args = if force do
+      %{city_id: city_id, force: true}
+    else
+      %{city_id: city_id}
+    end
+
+    case CityCoordinateCalculationJob.new(args) |> Oban.insert() do
+      {:ok, _job} ->
+        :scheduled
+      {:error, %Ecto.Changeset{errors: [args: {"has already been scheduled", _}]}} ->
+        Logger.debug("Job already scheduled for city #{city_name}")
+        :skipped
+      {:error, reason} ->
+        Logger.error("Failed to schedule calculation for city #{city_name}: #{inspect(reason)}")
+        :error
+    end
+  rescue
+    error ->
+      Logger.error("Error scheduling calculation for city #{city_name}: #{inspect(error)}")
+      :error
+  end
+end


### PR DESCRIPTION
### TL;DR

Added automatic city coordinate calculation based on venue locations to improve map accuracy.

### What changed?

- Added a new `CityCoordinateCalculationJob` that calculates city center coordinates based on the average location of all venues within that city
- Created a maintenance queue in Oban configuration with 2 workers
- Updated the `BaseJob` to automatically schedule coordinate recalculation after successful event syncing
- Added a Mix task `discovery.calculate_city_coordinates` to manually trigger coordinate calculations for all cities or a specific city

### How to test?

1. Run the Mix task to calculate coordinates for all cities:
2. Or calculate for a specific city:
3. Force recalculation even if recently updated:
4. Verify that city coordinates are updated in the database and reflect the center of venue activity

### Why make this change?

This change ensures city coordinates reflect the actual center of venue activity rather than geographic/political boundaries. By calculating the average position of all venues in a city, we get a more accurate representation of where events are actually happening, which improves map visualization and user experience. The job runs automatically after scraping but at most once per 24 hours to avoid unnecessary processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
    - Automatically recalculates city center coordinates from venue locations in the background.
    - Recalculation runs at most once every 24 hours per city, with retry and priority handling.
    - Coordinates are refreshed after successful data syncs.
    - New CLI task to schedule coordinate recalculation for all cities or a specific city, with an option to force updates.
- Chores
    - Added a dedicated maintenance queue with controlled concurrency; no changes to existing queues or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->