### PR TITLE
new style

### DIFF
--- a/CITY_FILTER_ISSUES.md
+++ b/CITY_FILTER_ISSUES.md
@@ -1,0 +1,127 @@
+# City Filters Broken: Hard-coded 100 event limit, category filtering non-functional, radius always active
+
+## Problem Summary
+
+The city event filtering functionality has multiple critical issues that make it appear broken to users. All issues stem from architectural problems in the event fetching pipeline.
+
+## Issues Identified
+
+### 1. **Hard-coded 100 Event Limit (Most Critical)**
+
+**Problem**: Changing radius from 50km to 100km still shows exactly 100 events
+**Root Cause**: PublicEventsEnhanced.list_events() has @max_limit 100 that caps all results
+
+**Location**: `lib/eventasaurus_discovery/public_events_enhanced.ex:14`
+```elixir
+@max_limit 100  # This caps ALL results regardless of radius
+```
+
+**Code Flow**:
+```elixir
+# lib/eventasaurus_web/live/city_live/index.ex:575
+query_filters = Map.merge(filters, %{
+  page_size: 1000,  # Requesting 1000 events
+  page: 1
+})
+
+all_events = PublicEventsEnhanced.list_events(query_filters)  # Returns max 100
+# Then radius filtering on only 100 events -> same result for any radius
+```
+
+**Fix Needed**: Remove or significantly increase @max_limit for geographic filtering, OR implement radius filtering at database level instead of post-processing.
+
+### 2. **Radius Filter Always Shows as "Active"**
+
+**Problem**: Radius filter shows as active even with default 50km setting
+**Root Cause**: active_filter_count() checks `filters.radius_km != 25` but default changed to 50km
+
+**Location**: `lib/eventasaurus_web/live/city_live/index.ex:712-713`
+```elixir
+@default_radius_km 50  # Changed from 25
+count = if filters.radius_km && filters.radius_km != 25, do: count + 1, else: count  # Still checking != 25
+```
+
+**Fix Needed**: Update logic to check against actual default: `filters.radius_km != @default_radius_km`
+
+### 3. **Category Filtering Non-Functional**
+
+**Problem**: Checking categories doesn't filter events, still shows all categories
+**Root Cause**: Categories passed to PublicEventsEnhanced but no verification it applies filtering
+
+**Location**: `lib/eventasaurus_web/live/city_live/index.ex:560-570`
+```elixir
+query_filters = Map.merge(filters, %{
+  categories: filters.categories,  # Passed but not working?
+  # ...
+})
+```
+
+**Fix Needed**: Verify PublicEventsEnhanced.filter_by_categories() works properly, OR implement category filtering in city-specific pipeline.
+
+### 4. **Wrong Category Display (Museum Banksy)**
+
+**Problem**: Museum Banksy shows as "Festivals" instead of "Theatre" like on Activities page
+**Root Cause**: Using `List.first(@event.categories)` instead of preferred category logic
+
+**Location**: `lib/eventasaurus_web/live/city_live/index.ex:462`
+```elixir
+<% category = List.first(@event.categories) %>  # Naive first category
+```
+
+**Same Issue**: Activities page has identical code at `lib/eventasaurus_web/live/public_events_index_live.ex:634`
+
+**Fix Needed**: Implement preferred category logic that:
+- Never shows "Other" if other categories exist
+- Shows most relevant/preferred category based on priority system
+
+### 5. **"Other" Category Regression**
+
+**Problem**: Events showing "Other" category when they have more specific categories
+**Root Cause**: Same as #4 - naive `List.first()` approach lost preferred category logic
+**Fix Needed**: Same as #4
+
+## Expected Behavior
+
+City pages should mirror Activities page functionality exactly, with only radius filtering as the difference:
+
+- ✅ **Radius filtering**: Should actually change event count when radius changes
+- ✅ **Category filtering**: Should filter events when categories selected
+- ✅ **Category display**: Should show preferred category, never "Other" if alternatives exist
+- ✅ **Filter state**: Should only show filters as active when they differ from defaults
+
+## Files Modified in Recent Changes
+
+```bash
+$ git status --porcelain
+M lib/eventasaurus_discovery/locations.ex
+M lib/eventasaurus_web/live/city_live/index.ex
+M lib/eventasaurus_web/live/city_live/search.ex
+? lib/eventasaurus_web/live/city_live/search.html.heex
+```
+
+## Proposed Solutions
+
+### Short-term (Fix Critical Issues)
+1. **Increase @max_limit** in PublicEventsEnhanced to 500+ for geographic contexts
+2. **Fix active_filter_count** to check against @default_radius_km
+3. **Debug category filtering** in PublicEventsEnhanced pipeline
+
+### Long-term (Architectural Fix)
+1. **Implement radius filtering at database level** instead of post-processing
+2. **Create preferred category logic** that both Activities and City pages use
+3. **Add integration tests** for city filtering to prevent regressions
+
+## Testing Steps to Reproduce
+
+1. Navigate to http://localhost:4000/c/krakow
+2. Open Filters panel (should work now)
+3. Change radius from 50km → 100km → Notice count stays exactly 100 events
+4. Select any category → Notice no filtering happens
+5. Observe Museum Banksy shows as "Festivals" instead of preferred category
+
+## Business Impact
+
+- **User Confusion**: Filters appear broken, radius changes don't work
+- **Poor UX**: Users can't effectively filter city events
+- **Data Inconsistency**: Same events show different categories on different pages
+- **Trust Issues**: Static 100 event count looks suspicious and hard-coded

--- a/lib/eventasaurus_discovery/locations.ex
+++ b/lib/eventasaurus_discovery/locations.ex
@@ -1,0 +1,262 @@
+defmodule EventasaurusDiscovery.Locations do
+  @moduledoc """
+  Context module for location-based queries and city management.
+
+  Provides functions for city lookups, radius-based event queries,
+  and geographic calculations using PostGIS.
+  """
+
+  import Ecto.Query
+  alias EventasaurusApp.Repo
+  alias EventasaurusDiscovery.Locations.City
+  alias EventasaurusDiscovery.PublicEvents
+  alias EventasaurusDiscovery.PublicEventsEnhanced
+
+  @doc """
+  Get a city by its slug.
+
+  ## Examples
+
+      iex> Locations.get_city_by_slug("krakow")
+      %City{name: "Krakow", slug: "krakow", ...}
+
+      iex> Locations.get_city_by_slug("invalid")
+      nil
+  """
+  def get_city_by_slug(slug) when is_binary(slug) do
+    Repo.one(
+      from c in City,
+      where: c.slug == ^slug,
+      preload: [:country]
+    )
+  end
+
+  @doc """
+  Get a city by its slug, raising if not found.
+
+  ## Examples
+
+      iex> Locations.get_city_by_slug!("krakow")
+      %City{name: "Krakow", slug: "krakow", ...}
+
+      iex> Locations.get_city_by_slug!("invalid")
+      ** (Ecto.NoResultsError)
+  """
+  def get_city_by_slug!(slug) do
+    case get_city_by_slug(slug) do
+      nil -> raise Ecto.NoResultsError, queryable: City
+      city -> city
+    end
+  end
+
+  @doc """
+  Get events for a city using radius-based queries.
+  Uses the existing optimized by_location function from PublicEvents.
+
+  ## Options
+    * `:radius_km` - Search radius in kilometers (default: 25)
+    * `:limit` - Maximum number of events to return (default: 50)
+    * `:upcoming_only` - Only return upcoming events (default: true)
+
+  ## Examples
+
+      iex> city = Locations.get_city_by_slug!("krakow")
+      iex> Locations.get_city_events(city, radius_km: 30)
+      [%PublicEvent{...}, ...]
+  """
+  def get_city_events(%City{} = city, opts \\ []) do
+    radius_km = Keyword.get(opts, :radius_km, 25)
+    limit = Keyword.get(opts, :limit, 50)
+    upcoming_only = Keyword.get(opts, :upcoming_only, true)
+    language = Keyword.get(opts, :language, "en")
+
+    # Convert Decimal to float for coordinates
+    lat = if city.latitude, do: Decimal.to_float(city.latitude), else: nil
+    lng = if city.longitude, do: Decimal.to_float(city.longitude), else: nil
+
+    if lat && lng do
+      # Use PublicEventsEnhanced to get properly formatted events with categories
+      # but then filter by radius manually since it doesn't support radius filtering
+      enhanced_opts = [
+        show_past: not upcoming_only,
+        limit: limit * 3, # Get more to account for radius filtering
+        language: language
+      ]
+
+      all_enhanced_events = PublicEventsEnhanced.list_events(enhanced_opts)
+
+      # Filter by radius using PostGIS distance calculation
+      radius_meters = radius_km * 1000
+
+      filtered_events = Enum.filter(all_enhanced_events, fn event ->
+        case event.venue do
+          %{latitude: venue_lat, longitude: venue_lng} when not is_nil(venue_lat) and not is_nil(venue_lng) ->
+            # Convert Decimal to float if needed
+            venue_lat = if is_struct(venue_lat, Decimal), do: Decimal.to_float(venue_lat), else: venue_lat
+            venue_lng = if is_struct(venue_lng, Decimal), do: Decimal.to_float(venue_lng), else: venue_lng
+
+            # Calculate distance using the same query we use elsewhere
+            query = """
+            SELECT ST_Distance(
+              ST_MakePoint($1::float, $2::float)::geography,
+              ST_MakePoint($3::float, $4::float)::geography
+            ) as distance_meters
+            """
+
+            case Repo.query(query, [lng, lat, venue_lng, venue_lat]) do
+              {:ok, %{rows: [[distance]]}} -> distance <= radius_meters
+              _ -> false
+            end
+          _ ->
+            false
+        end
+      end)
+
+      # Take only the requested limit
+      Enum.take(filtered_events, limit)
+    else
+      # Return empty list if city has no coordinates yet
+      []
+    end
+  end
+
+  defp get_cover_image_url(event) do
+    # Check if sources are loaded
+    case event do
+      %{sources: %Ecto.Association.NotLoaded{}} ->
+        # Need to preload sources if not loaded
+        event = Repo.preload(event, :sources)
+        extract_image_from_sources(event.sources)
+      %{sources: sources} when is_list(sources) ->
+        extract_image_from_sources(sources)
+      _ ->
+        nil
+    end
+  end
+
+  defp extract_image_from_sources([]), do: nil
+  defp extract_image_from_sources(sources) do
+    # Sort by priority and get first image_url
+    sources
+    |> Enum.sort_by(fn source ->
+      priority = case source.metadata do
+        %{"priority" => p} when is_integer(p) -> p
+        %{"priority" => p} when is_binary(p) ->
+          case Integer.parse(p) do
+            {num, _} -> num
+            _ -> 10
+          end
+        _ -> 10
+      end
+
+      # Use negative timestamp to sort newest first
+      timestamp = case source.last_seen_at do
+        %DateTime{} = dt -> -DateTime.to_unix(dt)
+        _ -> 0
+      end
+
+      {priority, timestamp}
+    end)
+    |> Enum.find_value(fn source ->
+      case source.image_url do
+        url when is_binary(url) and url != "" -> url
+        _ -> nil
+      end
+    end)
+  end
+
+  @doc """
+  Get nearby cities based on coordinates.
+
+  ## Options
+    * `:radius_km` - Search radius in kilometers (default: 100)
+    * `:limit` - Maximum number of cities to return (default: 10)
+
+  ## Examples
+
+      iex> Locations.get_nearby_cities(50.0614, 19.9366, radius_km: 50)
+      [%City{name: "Katowice", ...}, ...]
+  """
+  def get_nearby_cities(lat, lng, opts \\ []) when is_number(lat) and is_number(lng) do
+    radius_km = Keyword.get(opts, :radius_km, 100)
+    limit = Keyword.get(opts, :limit, 10)
+
+    from(c in City,
+      where: not is_nil(c.latitude) and not is_nil(c.longitude),
+      where: fragment(
+        "ST_DWithin(
+          ST_MakePoint(?::float, ?::float)::geography,
+          ST_MakePoint(?::float, ?::float)::geography,
+          ?
+        )",
+        ^lng, ^lat,
+        c.longitude, c.latitude,
+        ^(radius_km * 1000)  # Convert to meters
+      ),
+      order_by: fragment(
+        "ST_Distance(
+          ST_MakePoint(?::float, ?::float)::geography,
+          ST_MakePoint(?::float, ?::float)::geography
+        )",
+        ^lng, ^lat,
+        c.longitude, c.latitude
+      ),
+      limit: ^limit,
+      preload: [:country]
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  List all cities with coordinates.
+
+  ## Options
+    * `:limit` - Maximum number of cities to return (default: 100)
+    * `:country_id` - Filter by country ID
+
+  ## Examples
+
+      iex> Locations.list_cities_with_coordinates()
+      [%City{name: "Krakow", latitude: #Decimal<50.0614>, ...}, ...]
+  """
+  def list_cities_with_coordinates(opts \\ []) do
+    limit = Keyword.get(opts, :limit, 100)
+
+    query = from c in City,
+      where: not is_nil(c.latitude) and not is_nil(c.longitude),
+      order_by: [asc: c.name],
+      limit: ^limit,
+      preload: [:country]
+
+    query = case Keyword.get(opts, :country_id) do
+      nil -> query
+      country_id -> where(query, [c], c.country_id == ^country_id)
+    end
+
+    Repo.all(query)
+  end
+
+  @doc """
+  Calculate distance between two points in kilometers.
+
+  ## Examples
+
+      iex> Locations.calculate_distance(50.0614, 19.9366, 52.2297, 21.0122)
+      251.8  # Krakow to Warsaw in km
+  """
+  def calculate_distance(lat1, lng1, lat2, lng2)
+      when is_number(lat1) and is_number(lng1) and is_number(lat2) and is_number(lng2) do
+
+    query = """
+    SELECT ST_Distance(
+      ST_MakePoint($1::float, $2::float)::geography,
+      ST_MakePoint($3::float, $4::float)::geography
+    ) / 1000.0 as distance_km
+    """
+
+    case Repo.query(query, [lng1, lat1, lng2, lat2]) do
+      {:ok, %{rows: [[distance_km]]}} -> Float.round(distance_km, 1)
+      _ -> nil
+    end
+  end
+end

--- a/lib/eventasaurus_discovery/public_events_enhanced.ex
+++ b/lib/eventasaurus_discovery/public_events_enhanced.ex
@@ -11,7 +11,7 @@ defmodule EventasaurusDiscovery.PublicEventsEnhanced do
   alias EventasaurusDiscovery.Locations.City
 
   @default_limit 20
-  @max_limit 100
+  @max_limit 500
 
   @doc """
   List events with comprehensive filtering options.

--- a/lib/eventasaurus_web/helpers/category_helpers.ex
+++ b/lib/eventasaurus_web/helpers/category_helpers.ex
@@ -1,0 +1,80 @@
+defmodule EventasaurusWeb.Helpers.CategoryHelpers do
+  @moduledoc """
+  Shared helper functions for category display logic.
+  Ensures consistent category selection across all pages.
+  """
+
+  @doc """
+  Gets the preferred category from a list of categories.
+
+  Rules:
+  1. Never show "Other" if any other category exists
+  2. Prioritize categories by predefined order
+  3. Return the first non-"Other" category if available
+
+  ## Examples
+
+      iex> get_preferred_category([%{name: "Other"}, %{name: "Theatre"}])
+      %{name: "Theatre"}
+
+      iex> get_preferred_category([%{name: "Festivals"}, %{name: "Theatre"}])
+      %{name: "Festivals"}
+  """
+  def get_preferred_category(nil), do: nil
+  def get_preferred_category([]), do: nil
+  def get_preferred_category(categories) when is_list(categories) do
+    # Priority order for categories (most specific/relevant first)
+    priority_order = [
+      "Concerts",
+      "Theatre",
+      "Comedy",
+      "Sports",
+      "Film",
+      "Arts",
+      "Festivals",
+      "Education",
+      "Business",
+      "Family",
+      "Food & Drink",
+      "Nightlife",
+      "Community",
+      "Other"  # Always last priority
+    ]
+
+    # Sort categories by priority order
+    sorted_categories = Enum.sort_by(categories, fn category ->
+      category_name = Map.get(category, :name) || Map.get(category, "name")
+
+      # Find index in priority order, default to 999 if not found
+      priority_index = Enum.find_index(priority_order, &(&1 == category_name))
+      priority_index || 999
+    end)
+
+    # Return first category that isn't "Other", or first category if all are "Other"
+    case sorted_categories do
+      [] -> nil
+      [single] -> single
+      multiple ->
+        # Find first non-"Other" category
+        non_other = Enum.find(multiple, fn cat ->
+          name = Map.get(cat, :name) || Map.get(cat, "name")
+          name != "Other"
+        end)
+
+        # Return non-"Other" if found, otherwise return first (should never be only "Other" categories)
+        non_other || List.first(multiple)
+    end
+  end
+
+  @doc """
+  Checks if a category list contains only "Other" categories.
+  """
+  def only_other_categories?(nil), do: false
+  def only_other_categories?([]), do: false
+  def only_other_categories?(categories) when is_list(categories) do
+    Enum.all?(categories, fn cat ->
+      name = Map.get(cat, :name) || Map.get(cat, "name")
+      name == "Other"
+    end)
+  end
+end

--- a/lib/eventasaurus_web/live/city_hooks.ex
+++ b/lib/eventasaurus_web/live/city_hooks.ex
@@ -1,0 +1,27 @@
+defmodule EventasaurusWeb.Live.CityHooks do
+  @moduledoc """
+  LiveView hooks for city-based pages.
+
+  Assigns the current city from the URL parameters to the socket.
+  """
+
+  import Phoenix.Component, only: [assign: 2]
+  alias EventasaurusDiscovery.Locations
+
+  def on_mount(:assign_city, params, _session, socket) do
+    city_slug = params["city_slug"]
+
+    case Locations.get_city_by_slug(city_slug) do
+      nil ->
+        {:halt, socket}
+
+      city ->
+        if city.latitude && city.longitude do
+          {:cont, assign(socket, current_city: city)}
+        else
+          # City exists but has no coordinates
+          {:halt, socket}
+        end
+    end
+  end
+end

--- a/lib/eventasaurus_web/live/city_live/events.ex
+++ b/lib/eventasaurus_web/live/city_live/events.ex
@@ -1,0 +1,12 @@
+defmodule EventasaurusWeb.CityLive.Events do
+  @moduledoc """
+  LiveView for city events with timeframe filtering.
+  """
+  use EventasaurusWeb, :live_view
+
+  # Temporary stub - redirects to index
+  @impl true
+  def mount(%{"city_slug" => city_slug}, _session, socket) do
+    {:ok, push_navigate(socket, to: ~p"/c/#{city_slug}")}
+  end
+end

--- a/lib/eventasaurus_web/live/city_live/index.ex
+++ b/lib/eventasaurus_web/live/city_live/index.ex
@@ -1,0 +1,847 @@
+defmodule EventasaurusWeb.CityLive.Index do
+  @moduledoc """
+  LiveView for city-based event discovery pages.
+
+  Displays events within a configurable radius of a city's center,
+  using the city's dynamically calculated coordinates.
+  """
+
+  use EventasaurusWeb, :live_view
+
+  alias EventasaurusDiscovery.Locations
+  alias EventasaurusDiscovery.PublicEventsEnhanced
+  alias EventasaurusDiscovery.Pagination
+  alias EventasaurusDiscovery.Categories
+  alias EventasaurusApp.Repo
+  alias EventasaurusWeb.Helpers.CategoryHelpers
+
+  @default_radius_km 50
+  @max_radius_km 100
+  @min_radius_km 5
+
+  @impl true
+  def mount(%{"city_slug" => city_slug}, _session, socket) do
+    case Locations.get_city_by_slug(city_slug) do
+      nil ->
+        {:ok,
+         socket
+         |> put_flash(:error, "City not found")
+         |> push_navigate(to: ~p"/activities")}
+
+      city ->
+        if city.latitude && city.longitude do
+          # Get language from session or default to English
+          language = get_connect_params(socket)["locale"] || "en"
+
+          {:ok,
+           socket
+           |> assign(:city, city)
+           |> assign(:language, language)
+           |> assign(:radius_km, @default_radius_km)
+           |> assign(:view_mode, "grid")
+           |> assign(:filters, default_filters())
+           |> assign(:show_filters, false)
+           |> assign(:loading, false)
+           |> assign(:total_events, 0)
+           |> assign(:page_title, page_title(city))
+           |> assign(:meta_description, meta_description(city))
+           |> assign(:categories, Categories.list_categories())
+           |> assign(:events, [])
+           |> assign(:pagination, %Pagination{entries: [], page_number: 1, page_size: 21, total_entries: 0, total_pages: 0})
+           |> fetch_events()
+           |> fetch_nearby_cities()}
+        else
+          {:ok,
+           socket
+           |> put_flash(:error, "City location data is being processed. Please try again later.")
+           |> push_navigate(to: ~p"/activities")}
+        end
+    end
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    socket =
+      socket
+      |> apply_params_to_filters(params)
+      |> fetch_events()
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("search", %{"search" => search_term}, socket) do
+    filters = Map.put(socket.assigns.filters, :search, search_term)
+
+    socket =
+      socket
+      |> assign(:filters, filters)
+      |> fetch_events()
+      |> push_patch(to: build_path(socket, filters))
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("clear_search", _params, socket) do
+    filters = Map.put(socket.assigns.filters, :search, nil)
+
+    socket =
+      socket
+      |> assign(:filters, filters)
+      |> fetch_events()
+      |> push_patch(to: build_path(socket, filters))
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("filter", %{"filter" => filter_params}, socket) do
+    radius_km = parse_integer(filter_params["radius"]) || @default_radius_km
+
+    filters = %{
+      search: socket.assigns.filters.search,
+      categories: parse_id_list(filter_params["categories"]),
+      radius_km: radius_km,
+      sort_by: parse_sort(filter_params["sort_by"]),
+      sort_order: :asc,
+      page: 1,
+      page_size: 21
+    }
+
+    socket =
+      socket
+      |> assign(:filters, filters)
+      |> assign(:radius_km, radius_km)
+      |> fetch_events()
+      |> push_patch(to: build_path(socket, filters))
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("clear_filters", _params, socket) do
+    cleared_filters = default_filters()
+
+    socket =
+      socket
+      |> assign(:filters, cleared_filters)
+      |> assign(:radius_km, @default_radius_km)
+      |> fetch_events()
+      |> push_patch(to: build_path(socket, cleared_filters))
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("toggle_filters", _params, socket) do
+    {:noreply, update(socket, :show_filters, &(!&1))}
+  end
+
+  @impl true
+  def handle_event("change_view", %{"view" => view_mode}, socket) do
+    {:noreply, assign(socket, :view_mode, view_mode)}
+  end
+
+  @impl true
+  def handle_event("paginate", %{"page" => page}, socket) do
+    page = String.to_integer(page)
+    updated_filters = Map.put(socket.assigns.filters, :page, page)
+
+    socket =
+      socket
+      |> assign(:filters, updated_filters)
+      |> fetch_events()
+      |> push_patch(to: build_path(socket, updated_filters))
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-screen bg-gray-50">
+      <!-- Header -->
+      <div class="bg-white shadow-sm border-b">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <div class="flex justify-between items-center">
+            <h1 class="text-3xl font-bold text-gray-900">
+              Events in {@city.name}
+            </h1>
+            <div class="flex items-center space-x-4">
+              <!-- View Mode Toggle -->
+              <div class="flex bg-gray-100 rounded-lg p-1">
+                <button
+                  phx-click="change_view"
+                  phx-value-view="grid"
+                  class={"px-3 py-1 rounded #{if @view_mode == "grid", do: "bg-white shadow-sm", else: ""}"}
+                >
+                  <Heroicons.squares_2x2 class="w-5 h-5" />
+                </button>
+                <button
+                  phx-click="change_view"
+                  phx-value-view="list"
+                  class={"px-3 py-1 rounded #{if @view_mode == "list", do: "bg-white shadow-sm", else: ""}"}
+                >
+                  <Heroicons.list_bullet class="w-5 h-5" />
+                </button>
+              </div>
+
+              <!-- Filter Toggle -->
+              <button
+                phx-click="toggle_filters"
+                class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center space-x-2"
+              >
+                <Heroicons.funnel class="w-5 h-5" />
+                <span>Filters</span>
+                <%= if active_filter_count(@filters) > 0 do %>
+                  <span class="ml-2 bg-blue-700 px-2 py-0.5 rounded-full text-xs">
+                    <%= active_filter_count(@filters) %>
+                  </span>
+                <% end %>
+              </button>
+            </div>
+          </div>
+
+          <!-- Search Bar -->
+          <div class="mt-4">
+            <form phx-submit="search" class="relative">
+              <input
+                type="text"
+                name="search"
+                value={@filters.search}
+                placeholder="Search events..."
+                class="w-full px-4 py-3 pr-12 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+              <button type="submit" class="absolute right-3 top-3.5">
+                <Heroicons.magnifying_glass class="w-5 h-5 text-gray-500" />
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <!-- Filters Panel -->
+      <div :if={@show_filters} class="bg-white border-b">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <.filter_panel
+            filters={@filters}
+            radius_km={@radius_km}
+            categories={@categories}
+          />
+        </div>
+      </div>
+
+      <!-- Active Filters -->
+      <div :if={active_filter_count(@filters) > 0} class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
+        <div class="flex items-center space-x-2">
+          <span class="text-sm text-gray-600">Active filters:</span>
+          <.active_filter_tags filters={@filters} radius_km={@radius_km} categories={@categories} />
+          <button
+            phx-click="clear_filters"
+            class="ml-4 text-sm text-blue-600 hover:text-blue-800"
+          >
+            Clear all
+          </button>
+        </div>
+      </div>
+
+      <!-- Events Grid/List -->
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <%= if @loading do %>
+          <div class="flex justify-center py-12">
+            <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+          </div>
+        <% else %>
+          <%= if @events == [] do %>
+            <div class="text-center py-12">
+              <Heroicons.calendar_days class="mx-auto h-12 w-12 text-gray-400" />
+              <h3 class="mt-2 text-lg font-medium text-gray-900">
+                No events found
+              </h3>
+              <p class="mt-1 text-sm text-gray-500">
+                Try adjusting your filters or search query
+              </p>
+            </div>
+          <% else %>
+            <div class="mb-4 text-sm text-gray-600">
+              Found {@total_events} events
+            </div>
+
+            <%= if @view_mode == "grid" do %>
+              <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <.event_card :for={event <- @events} event={event} language="en" />
+              </div>
+            <% else %>
+              <div class="space-y-4">
+                <.event_list_item :for={event <- @events} event={event} language="en" />
+              </div>
+            <% end %>
+
+            <!-- Pagination -->
+            <div class="mt-8">
+              <.pagination pagination={@pagination} />
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+
+    </div>
+    """
+  end
+
+  # Component: Filter Panel with radius selector
+  defp filter_panel(assigns) do
+    ~H"""
+    <form phx-change="filter" class="space-y-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <!-- Search Radius -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-2">
+            Search Radius
+          </label>
+          <select
+            name="filter[radius]"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md"
+          >
+            <option value="5" selected={@radius_km == 5}>5 km</option>
+            <option value="10" selected={@radius_km == 10}>10 km</option>
+            <option value="25" selected={@radius_km == 25}>25 km</option>
+            <option value="50" selected={@radius_km == 50}>50 km</option>
+            <option value="100" selected={@radius_km == 100}>100 km</option>
+          </select>
+        </div>
+
+        <!-- Sort By -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-2">
+            Sort By
+          </label>
+          <select
+            name="filter[sort_by]"
+            class="w-full px-3 py-2 border border-gray-300 rounded-md"
+          >
+            <option value="starts_at" selected={@filters.sort_by == :starts_at}>
+              Date
+            </option>
+            <option value="distance" selected={@filters.sort_by == :distance}>
+              Distance
+            </option>
+            <option value="title" selected={@filters.sort_by == :title}>
+              Title
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Categories -->
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-2">
+          Categories
+        </label>
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
+          <%= for category <- @categories do %>
+            <label class="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                name="filter[categories][]"
+                value={category.id}
+                checked={category.id in @filters.categories}
+                class="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span class="text-sm text-gray-700"><%= category.name %></span>
+            </label>
+          <% end %>
+        </div>
+      </div>
+    </form>
+    """
+  end
+
+  # Component: Active Filter Tags
+  defp active_filter_tags(assigns) do
+    ~H"""
+    <div class="flex flex-wrap gap-2">
+      <%= if @filters.search do %>
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800">
+          Search: <%= @filters.search %>
+          <button phx-click="clear_search" class="ml-2">
+            <Heroicons.x_mark class="w-3 h-3" />
+          </button>
+        </span>
+      <% end %>
+
+      <%= if @radius_km != 50 do %>
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800">
+          Radius: <%= @radius_km %>km
+        </span>
+      <% end %>
+
+      <%= for category_id <- @filters.categories do %>
+        <% category = Enum.find(@categories, & &1.id == category_id) %>
+        <%= if category do %>
+          <span class="inline-flex items-center px-3 py-1 rounded-full text-sm bg-blue-100 text-blue-800">
+            <%= category.name %>
+          </span>
+        <% end %>
+      <% end %>
+    </div>
+    """
+  end
+
+  # Component: Pagination - EXACT same from Activities page
+  defp pagination(assigns) do
+    ~H"""
+    <nav class="flex justify-center">
+      <div class="flex items-center space-x-2">
+        <!-- Previous -->
+        <button
+          :if={@pagination.page_number > 1}
+          phx-click="paginate"
+          phx-value-page={@pagination.page_number - 1}
+          class="px-3 py-2 border border-gray-300 rounded-md hover:bg-gray-50"
+        >
+          Previous
+        </button>
+
+        <!-- Page Numbers -->
+        <div class="flex space-x-1">
+          <%= for page <- Pagination.page_links(@pagination) do %>
+            <%= if page == :ellipsis do %>
+              <span class="px-3 py-2">...</span>
+            <% else %>
+              <button
+                phx-click="paginate"
+                phx-value-page={page}
+                class={"px-3 py-2 rounded-md #{if page == @pagination.page_number, do: "bg-blue-600 text-white", else: "border border-gray-300 hover:bg-gray-50"}"}
+              >
+                <%= page %>
+              </button>
+            <% end %>
+          <% end %>
+        </div>
+
+        <!-- Next -->
+        <button
+          :if={@pagination.page_number < @pagination.total_pages}
+          phx-click="paginate"
+          phx-value-page={@pagination.page_number + 1}
+          class="px-3 py-2 border border-gray-300 rounded-md hover:bg-gray-50"
+        >
+          Next
+        </button>
+      </div>
+    </nav>
+    """
+  end
+
+  # EXACT same event_card component from Activities page with multi-occurrence indicators
+  defp event_card(assigns) do
+    alias EventasaurusDiscovery.PublicEvents.PublicEvent
+
+    ~H"""
+    <.link navigate={~p"/activities/#{@event.slug}"} class="block">
+      <div class={"bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow #{if PublicEvent.recurring?(@event), do: "ring-2 ring-green-500 ring-offset-2", else: ""}"}>
+        <!-- Event Image -->
+        <div class="h-48 bg-gray-200 rounded-t-lg relative overflow-hidden">
+          <%= if Map.get(@event, :cover_image_url) do %>
+            <img src={Map.get(@event, :cover_image_url)} alt={@event.title} class="w-full h-full object-cover" loading="lazy">
+          <% else %>
+            <div class="w-full h-full flex items-center justify-center">
+              <svg class="w-12 h-12 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
+              </svg>
+            </div>
+          <% end %>
+
+          <%= if @event.categories && @event.categories != [] do %>
+            <% category = CategoryHelpers.get_preferred_category(@event.categories) %>
+            <%= if category && category.color do %>
+              <div
+                class="absolute top-3 left-3 px-2 py-1 rounded-md text-xs font-medium text-white"
+                style={"background-color: #{category.color}"}
+              >
+                <%= category.name %>
+              </div>
+            <% end %>
+          <% end %>
+
+          <!-- Recurring Event Badge -->
+          <%= if PublicEvent.recurring?(@event) do %>
+            <div class="absolute top-3 right-3 bg-green-500 text-white px-2 py-1 rounded-md text-xs font-medium flex items-center">
+              <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd" />
+              </svg>
+              <%= PublicEvent.occurrence_count(@event) %> dates
+            </div>
+          <% end %>
+        </div>
+
+        <!-- Event Details -->
+        <div class="p-4">
+          <h3 class="font-semibold text-lg text-gray-900 line-clamp-2">
+            <%= @event.display_title || @event.title %>
+          </h3>
+
+          <div class="mt-2 flex items-center text-sm text-gray-600">
+            <Heroicons.calendar class="w-4 h-4 mr-1" />
+            <%= if PublicEvent.recurring?(@event) do %>
+              <span class="text-green-600 font-medium">
+                <%= PublicEvent.frequency_label(@event) %> • Next: <%= format_datetime(PublicEvent.next_occurrence_date(@event)) %>
+              </span>
+            <% else %>
+              <%= format_datetime(@event.starts_at) %>
+            <% end %>
+          </div>
+
+          <%= if @event.venue do %>
+            <div class="mt-1 flex items-center text-sm text-gray-600">
+              <Heroicons.map_pin class="w-4 h-4 mr-1" />
+              <%= @event.venue.name %>
+            </div>
+          <% end %>
+
+          <%= if @event.min_price || @event.max_price do %>
+            <div class="mt-2">
+              <span class="text-sm font-medium text-gray-900">
+                <%= format_price_range(@event) %>
+              </span>
+            </div>
+          <% else %>
+            <div class="mt-2">
+              <span class="text-sm font-medium text-green-600">
+                Free
+              </span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </.link>
+    """
+  end
+
+  # EXACT same event_list_item component from Activities page with multi-occurrence indicators
+  defp event_list_item(assigns) do
+    alias EventasaurusDiscovery.PublicEvents.PublicEvent
+
+    ~H"""
+    <.link navigate={~p"/activities/#{@event.slug}"} class="block">
+      <div class={"bg-white rounded-lg shadow hover:shadow-md transition-shadow p-6 #{if PublicEvent.recurring?(@event), do: "border-l-4 border-green-500", else: ""}"}>
+        <div class="flex gap-6">
+          <!-- Event Image -->
+          <div class="flex-shrink-0">
+            <div class="w-24 h-24 bg-gray-200 rounded-lg overflow-hidden relative">
+              <%= if Map.get(@event, :cover_image_url) do %>
+                <img src={Map.get(@event, :cover_image_url)} alt={@event.title} class="w-full h-full object-cover" loading="lazy">
+              <% else %>
+                <div class="w-full h-full flex items-center justify-center">
+                  <svg class="w-8 h-8 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
+                  </svg>
+                </div>
+              <% end %>
+
+              <!-- Stacked effect for recurring events -->
+              <%= if PublicEvent.recurring?(@event) do %>
+                <div class="absolute -bottom-1 -right-1 w-full h-full bg-white rounded-lg shadow -z-10"></div>
+                <div class="absolute -bottom-2 -right-2 w-full h-full bg-white rounded-lg shadow -z-20"></div>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="flex-1">
+            <div class="flex items-start justify-between">
+              <h3 class="text-xl font-semibold text-gray-900">
+                <%= @event.display_title || @event.title %>
+              </h3>
+
+              <%= if PublicEvent.recurring?(@event) do %>
+                <span class="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                  <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd" />
+                  </svg>
+                  <%= PublicEvent.occurrence_count(@event) %> dates
+                </span>
+              <% end %>
+            </div>
+
+            <div class="mt-2 flex flex-wrap gap-4 text-sm text-gray-600">
+              <div class="flex items-center">
+                <Heroicons.calendar class="w-4 h-4 mr-1" />
+                <%= if PublicEvent.recurring?(@event) do %>
+                  <span class="text-green-600 font-medium">
+                    <%= PublicEvent.frequency_label(@event) %> • Next: <%= format_datetime(PublicEvent.next_occurrence_date(@event)) %>
+                  </span>
+                <% else %>
+                  <%= format_datetime(@event.starts_at) %>
+                <% end %>
+              </div>
+
+              <div class="flex items-center">
+                <Heroicons.map_pin class="w-4 h-4 mr-1" />
+                <%= @event.venue.name %>
+              </div>
+
+              <%= if @event.categories != [] do %>
+                <div class="flex items-center">
+                  <Heroicons.tag class="w-4 h-4 mr-1" />
+                  <%= Enum.map_join(@event.categories, ", ", & &1.name) %>
+                </div>
+              <% end %>
+            </div>
+
+            <%= if @event.display_description do %>
+              <p class="mt-3 text-gray-600 line-clamp-2">
+                <%= @event.display_description %>
+              </p>
+            <% end %>
+          </div>
+
+          <div class="ml-6 text-right">
+            <%= if @event.min_price || @event.max_price do %>
+              <div class="text-lg font-semibold text-gray-900">
+                <%= format_price_range(@event) %>
+              </div>
+            <% else %>
+              <div class="text-lg font-semibold text-green-600">
+                Free
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </.link>
+    """
+  end
+
+  # Private functions
+
+  defp fetch_events(socket) do
+    city = socket.assigns.city
+    filters = socket.assigns.filters
+    language = socket.assigns.language
+
+    # Use EXACT same data pipeline as Activities page
+    query_filters = Map.merge(filters, %{
+      language: language,
+      sort_order: filters[:sort_order] || :asc,
+      # Start with higher limit since we'll filter by radius
+      page_size: 1000,
+      page: 1
+    })
+
+    # Get all enhanced events (same as Activities page)
+    all_events = PublicEventsEnhanced.list_events(query_filters)
+
+    # Apply geographic filtering if city has coordinates
+    lat = if city.latitude, do: Decimal.to_float(city.latitude), else: nil
+    lng = if city.longitude, do: Decimal.to_float(city.longitude), else: nil
+
+    geographic_events = if lat && lng do
+      radius_meters = filters.radius_km * 1000
+
+      Enum.filter(all_events, fn event ->
+        case event.venue do
+          %{latitude: venue_lat, longitude: venue_lng} when not is_nil(venue_lat) and not is_nil(venue_lng) ->
+            venue_lat = if is_struct(venue_lat, Decimal), do: Decimal.to_float(venue_lat), else: venue_lat
+            venue_lng = if is_struct(venue_lng, Decimal), do: Decimal.to_float(venue_lng), else: venue_lng
+
+            query = """
+            SELECT ST_Distance(
+              ST_MakePoint($1::float, $2::float)::geography,
+              ST_MakePoint($3::float, $4::float)::geography
+            ) as distance_meters
+            """
+
+            case Repo.query(query, [lng, lat, venue_lng, venue_lat]) do
+              {:ok, %{rows: [[distance]]}} -> distance <= radius_meters
+              _ -> false
+            end
+          _ ->
+            false
+        end
+      end)
+    else
+      []
+    end
+
+    # Paginate the filtered results manually
+    total_entries = length(geographic_events)
+    page = filters.page
+    page_size = filters.page_size
+    total_pages = ceil(total_entries / page_size)
+    offset = (page - 1) * page_size
+
+    paginated_events = geographic_events |> Enum.drop(offset) |> Enum.take(page_size)
+
+    pagination = %Pagination{
+      entries: paginated_events,
+      page_number: page,
+      page_size: page_size,
+      total_entries: total_entries,
+      total_pages: total_pages
+    }
+
+    socket
+    |> assign(:events, paginated_events)
+    |> assign(:pagination, pagination)
+    |> assign(:total_events, total_entries)
+    |> assign(:loading, false)
+  end
+
+  defp fetch_nearby_cities(socket) do
+    # No longer showing nearby cities
+    socket
+  end
+
+  defp parse_radius(nil), do: @default_radius_km
+  defp parse_radius(radius_str) do
+    case Integer.parse(radius_str) do
+      {radius, _} when radius >= @min_radius_km and radius <= @max_radius_km ->
+        radius
+      _ ->
+        @default_radius_km
+    end
+  end
+
+  defp page_title(city) do
+    "Events in #{city.name}, #{city.country.name} | Eventasaurus"
+  end
+
+  defp meta_description(city) do
+    "Discover upcoming events in #{city.name}, #{city.country.name}. Find concerts, festivals, workshops, and more happening near you."
+  end
+
+
+  defp active_filter_count(filters) do
+    count = 0
+    count = if filters.search && filters.search != "", do: count + 1, else: count
+    count = if filters.radius_km && filters.radius_km != @default_radius_km, do: count + 1, else: count
+    count = count + length(filters.categories || [])
+    count
+  end
+
+  defp parse_id_list(nil), do: []
+  defp parse_id_list([]), do: []
+  defp parse_id_list(ids) when is_list(ids) do
+    ids
+    |> Enum.map(fn id ->
+      case id do
+        id when is_integer(id) -> id
+        id when is_binary(id) ->
+          case Integer.parse(id) do
+            {num, _} -> num
+            _ -> nil
+          end
+        _ -> nil
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+  defp parse_id_list(ids) when is_binary(ids) do
+    ids
+    |> String.split(",")
+    |> Enum.map(fn id ->
+      case Integer.parse(id) do
+        {num, _} -> num
+        _ -> nil
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp format_datetime(nil), do: "TBD"
+  defp format_datetime(datetime) do
+    Calendar.strftime(datetime, "%b %d, %Y at %I:%M %p")
+  end
+
+  defp format_price_range(event) do
+    cond do
+      event.min_price && event.max_price && event.min_price == event.max_price ->
+        "$#{event.min_price}"
+
+      event.min_price && event.max_price ->
+        "$#{event.min_price} - $#{event.max_price}"
+
+      event.min_price ->
+        "From $#{event.min_price}"
+
+      event.max_price ->
+        "Up to $#{event.max_price}"
+
+      true ->
+        "Free"
+    end
+  end
+
+  defp default_filters do
+    %{
+      search: nil,
+      categories: [],
+      radius_km: @default_radius_km,
+      sort_by: :starts_at,
+      sort_order: :asc,
+      page: 1,
+      page_size: 21
+    }
+  end
+
+  defp apply_params_to_filters(socket, params) do
+    filters = %{
+      search: params["search"],
+      categories: parse_id_list(params["categories"]),
+      radius_km: parse_integer(params["radius"]) || socket.assigns.radius_km,
+      sort_by: parse_sort(params["sort"]),
+      sort_order: :asc,
+      page: parse_integer(params["page"]) || 1,
+      page_size: 21
+    }
+
+    socket
+    |> assign(:filters, filters)
+    |> assign(:radius_km, filters.radius_km)
+  end
+
+  defp build_path(socket, filters) do
+    params = build_filter_params(filters)
+    ~p"/c/#{socket.assigns.city.slug}?#{params}"
+  end
+
+  defp build_filter_params(filters) do
+    filters
+    |> Map.take([:search, :categories, :radius_km, :sort_by, :page])
+    |> Enum.reject(fn
+      {_k, nil} -> true
+      {_k, ""} -> true
+      {_k, []} -> true  # Empty categories list
+      {:page, 1} -> true
+      {:radius_km, @default_radius_km} -> true  # Don't include default radius
+      {:sort_by, :starts_at} -> true
+      _ -> false
+    end)
+    |> Enum.map(fn
+      {:categories, cats} when is_list(cats) -> {"categories", Enum.join(cats, ",")}
+      {:radius_km, radius} -> {"radius", to_string(radius)}
+      {:sort_by, sort} -> {"sort", to_string(sort)}
+      {:page, page} -> {"page", to_string(page)}
+      {k, v} -> {to_string(k), to_string(v)}
+    end)
+    |> Enum.into(%{})
+  end
+
+
+  defp parse_integer(nil), do: nil
+  defp parse_integer(""), do: nil
+  defp parse_integer(val) when is_binary(val) do
+    case Integer.parse(val) do
+      {num, _} -> num
+      :error -> nil
+    end
+  end
+
+  defp parse_sort(nil), do: :starts_at
+  defp parse_sort("distance"), do: :distance
+  defp parse_sort("title"), do: :title
+  defp parse_sort(_), do: :starts_at
+
+end

--- a/lib/eventasaurus_web/live/city_live/search.ex
+++ b/lib/eventasaurus_web/live/city_live/search.ex
@@ -1,0 +1,256 @@
+defmodule EventasaurusWeb.CityLive.Search do
+  @moduledoc """
+  LiveView for city-specific search.
+  """
+  use EventasaurusWeb, :live_view
+
+  alias EventasaurusDiscovery.Locations
+  alias EventasaurusDiscovery.Pagination
+  alias EventasaurusDiscovery.Categories
+
+  @impl true
+  def mount(%{"city_slug" => city_slug}, _session, socket) do
+    city = Locations.get_city_by_slug!(city_slug)
+
+    # Get language from session or default to English
+    language = get_connect_params(socket)["locale"] || "en"
+
+    socket =
+      socket
+      |> assign(:city, city)
+      |> assign(:language, language)
+      |> assign(:page_title, "Search Events in #{city.name}")
+      |> assign(:view_mode, "grid")
+      |> assign(:filters, default_filters())
+      |> assign(:categories, Categories.list_categories())
+      |> assign(:filter_facets, %{})
+      |> assign(:show_filters, false)
+      |> assign(:loading, false)
+      |> assign(:search_focused, true)  # Flag to auto-focus search on load
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    socket =
+      socket
+      |> apply_params_to_filters(params)
+      |> fetch_events()
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("search", %{"search" => search_term}, socket) do
+    filters = Map.put(socket.assigns.filters, :search, search_term)
+
+    socket =
+      socket
+      |> assign(:filters, filters)
+      |> fetch_events()
+      |> push_patch(
+        to: build_path(%{socket | assigns: Map.put(socket.assigns, :filters, filters)})
+      )
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("clear_search", _params, socket) do
+    filters = Map.put(socket.assigns.filters, :search, nil)
+
+    socket =
+      socket
+      |> assign(:filters, filters)
+      |> fetch_events()
+      |> push_patch(
+        to: build_path(%{socket | assigns: Map.put(socket.assigns, :filters, filters)})
+      )
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("filter", %{"filter" => filter_params}, socket) do
+    current_filters = socket.assigns.filters
+
+    new_filters = %{
+      categories: parse_id_list(filter_params["categories"]),
+      radius_km: parse_integer(filter_params["radius_km"]) || current_filters.radius_km,
+      start_date: parse_date(filter_params["start_date"]),
+      end_date: parse_date(filter_params["end_date"]),
+      min_price: parse_decimal(filter_params["min_price"]),
+      max_price: parse_decimal(filter_params["max_price"]),
+      sort_by: parse_sort(filter_params["sort_by"]),
+      sort_order: :asc,
+      search: current_filters.search,
+      page: 1,
+      page_size: current_filters.page_size
+    }
+
+    socket =
+      socket
+      |> assign(:filters, new_filters)
+      |> push_patch(
+        to: build_path(%{socket | assigns: Map.put(socket.assigns, :filters, new_filters)})
+      )
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("toggle_view", %{"mode" => mode}, socket) do
+    {:noreply, assign(socket, :view_mode, mode)}
+  end
+
+  @impl true
+  def handle_event("toggle_filters", _params, socket) do
+    {:noreply, assign(socket, :show_filters, !socket.assigns.show_filters)}
+  end
+
+  @impl true
+  def handle_event("paginate", %{"page" => page}, socket) do
+    page = String.to_integer(page)
+    filters = Map.put(socket.assigns.filters, :page, page)
+
+    socket =
+      socket
+      |> assign(:filters, filters)
+      |> fetch_events()
+      |> push_patch(
+        to: build_path(%{socket | assigns: Map.put(socket.assigns, :filters, filters)})
+      )
+
+    {:noreply, socket}
+  end
+
+  defp default_filters do
+    %{
+      categories: [],
+      radius_km: 25,
+      start_date: Date.utc_today(),
+      end_date: Date.add(Date.utc_today(), 90),
+      min_price: nil,
+      max_price: nil,
+      sort_by: :date,
+      sort_order: :asc,
+      search: nil,
+      page: 1,
+      page_size: 20
+    }
+  end
+
+  defp apply_params_to_filters(socket, params) do
+    filters = %{
+      socket.assigns.filters |
+      search: params["search"] || socket.assigns.filters.search,
+      page: parse_integer(params["page"]) || socket.assigns.filters.page,
+      radius_km: parse_integer(params["radius"]) || socket.assigns.filters.radius_km,
+      sort_by: parse_sort(params["sort"]) || socket.assigns.filters.sort_by
+    }
+
+    assign(socket, :filters, filters)
+  end
+
+  defp fetch_events(socket) do
+    city = socket.assigns.city
+    filters = socket.assigns.filters
+
+    events = if filters.search && String.trim(filters.search) != "" do
+      # Get events with search applied
+      base_events = Locations.get_city_events(city,
+        radius_km: filters.radius_km,
+        limit: 200,
+        upcoming_only: true
+      )
+
+      search_term = String.downcase(filters.search)
+
+      base_events
+      |> Enum.filter(fn event ->
+        title = String.downcase(Map.get(event, :title, ""))
+        desc = String.downcase(Map.get(event, :description, ""))
+
+        String.contains?(title, search_term) || String.contains?(desc, search_term)
+      end)
+    else
+      Locations.get_city_events(city,
+        radius_km: filters.radius_km,
+        limit: 200,
+        upcoming_only: true
+      )
+    end
+
+    # Apply sorting
+    sorted_events = sort_events(events, filters.sort_by)
+
+    # Paginate
+    paginated_result = Pagination.paginate(sorted_events, filters.page, filters.page_size)
+
+    assign(socket,
+      events: paginated_result.entries,
+      pagination: paginated_result,
+      total_events: length(events)
+    )
+  end
+
+  defp sort_events(events, :date), do: Enum.sort_by(events, & &1.start_time)
+  defp sort_events(events, :name), do: Enum.sort_by(events, & &1.title)
+  defp sort_events(events, :price) do
+    Enum.sort_by(events, fn event ->
+      Map.get(event, :price_low, 0)
+    end)
+  end
+  defp sort_events(events, _), do: events
+
+  defp build_path(socket) do
+    filters = socket.assigns.filters
+    city = socket.assigns.city
+
+    query_params = []
+    query_params = if filters.search, do: [{"search", filters.search} | query_params], else: query_params
+    query_params = if filters.page > 1, do: [{"page", filters.page} | query_params], else: query_params
+    query_params = if filters.radius_km != 25, do: [{"radius", filters.radius_km} | query_params], else: query_params
+    query_params = if filters.sort_by != :date, do: [{"sort", Atom.to_string(filters.sort_by)} | query_params], else: query_params
+
+    ~p"/c/#{city.slug}/search?#{query_params}"
+  end
+
+  defp parse_integer(nil), do: nil
+  defp parse_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, _} -> int
+      _ -> nil
+    end
+  end
+  defp parse_integer(value) when is_integer(value), do: value
+
+  defp parse_id_list(nil), do: []
+  defp parse_id_list(ids) when is_binary(ids) do
+    ids
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.to_integer/1)
+  end
+  defp parse_id_list(ids) when is_list(ids), do: ids
+
+  defp parse_date(nil), do: nil
+  defp parse_date(date_string) when is_binary(date_string) do
+    case Date.from_iso8601(date_string) do
+      {:ok, date} -> date
+      _ -> nil
+    end
+  end
+
+  defp parse_decimal(nil), do: nil
+  defp parse_decimal(value) when is_binary(value) do
+    case Decimal.parse(value) do
+      {decimal, _} -> decimal
+      _ -> nil
+    end
+  end
+
+  defp parse_sort(nil), do: :date
+  defp parse_sort(value) when is_binary(value), do: String.to_existing_atom(value)
+  defp parse_sort(value) when is_atom(value), do: value
+end

--- a/lib/eventasaurus_web/live/city_live/search.html.heex
+++ b/lib/eventasaurus_web/live/city_live/search.html.heex
@@ -1,0 +1,344 @@
+<div class="min-h-screen bg-gray-50">
+  <!-- Header -->
+  <div class="bg-white shadow-sm border-b">
+    <div class="container mx-auto px-4 py-6">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h1 class="text-3xl font-bold text-gray-900">
+            Search Events in <%= @city.name %>
+          </h1>
+          <p class="text-gray-600 mt-2">
+            Found <%= @total_events %> events
+          </p>
+        </div>
+
+        <div class="flex items-center gap-4">
+          <!-- View Mode Toggle -->
+          <div class="flex items-center bg-gray-100 rounded-lg p-1">
+            <button
+              phx-click="toggle_view"
+              phx-value-mode="grid"
+              class={"px-3 py-1.5 rounded-md text-sm font-medium transition-colors #{if @view_mode == "grid", do: "bg-white text-gray-900 shadow-sm", else: "text-gray-500"}"}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+              </svg>
+            </button>
+            <button
+              phx-click="toggle_view"
+              phx-value-mode="list"
+              class={"px-3 py-1.5 rounded-md text-sm font-medium transition-colors #{if @view_mode == "list", do: "bg-white text-gray-900 shadow-sm", else: "text-gray-500"}"}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- Filters Button -->
+          <button
+            phx-click="toggle_filters"
+            class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors flex items-center gap-2"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+            </svg>
+            Filters
+          </button>
+        </div>
+      </div>
+
+      <!-- Search Bar (auto-focused on this page) -->
+      <div class="mt-6">
+        <form phx-submit="search" phx-change="search" class="relative">
+          <input
+            type="text"
+            name="search"
+            value={@filters.search}
+            placeholder="Search for events, artists, venues..."
+            class="w-full px-4 py-3 pl-12 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            phx-mounted={@search_focused && JS.focus()}
+          />
+          <svg xmlns="http://www.w3.org/2000/svg" class="absolute left-4 top-3.5 h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <%= if @filters.search do %>
+            <button
+              type="button"
+              phx-click="clear_search"
+              class="absolute right-4 top-3.5 text-gray-400 hover:text-gray-600"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          <% end %>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Main Content -->
+  <div class="container mx-auto px-4 py-8">
+    <div class="flex gap-8">
+      <!-- Filters Panel -->
+      <div class={"transition-all duration-300 #{if @show_filters, do: "w-64 opacity-100", else: "w-0 opacity-0 overflow-hidden"}"}>
+        <%= if @show_filters do %>
+          <div class="bg-white rounded-lg shadow-md p-6">
+            <h3 class="text-lg font-semibold mb-4">Filters</h3>
+
+            <form phx-submit="filter">
+              <!-- Radius Filter -->
+              <div class="mb-6">
+                <label class="block text-sm font-medium text-gray-700 mb-2">
+                  Search Radius
+                </label>
+                <select
+                  name="filter[radius_km]"
+                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                >
+                  <option value="5" selected={@filters.radius_km == 5}>5 km</option>
+                  <option value="10" selected={@filters.radius_km == 10}>10 km</option>
+                  <option value="25" selected={@filters.radius_km == 25}>25 km</option>
+                  <option value="50" selected={@filters.radius_km == 50}>50 km</option>
+                  <option value="100" selected={@filters.radius_km == 100}>100 km</option>
+                </select>
+              </div>
+
+              <!-- Sort By -->
+              <div class="mb-6">
+                <label class="block text-sm font-medium text-gray-700 mb-2">
+                  Sort By
+                </label>
+                <select
+                  name="filter[sort_by]"
+                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                >
+                  <option value="date" selected={@filters.sort_by == :date}>Date</option>
+                  <option value="name" selected={@filters.sort_by == :name}>Name</option>
+                  <option value="price" selected={@filters.sort_by == :price}>Price</option>
+                </select>
+              </div>
+
+              <!-- Date Range -->
+              <div class="mb-6">
+                <label class="block text-sm font-medium text-gray-700 mb-2">
+                  Date Range
+                </label>
+                <input
+                  type="date"
+                  name="filter[start_date]"
+                  value={@filters.start_date}
+                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 mb-2"
+                />
+                <input
+                  type="date"
+                  name="filter[end_date]"
+                  value={@filters.end_date}
+                  class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                />
+              </div>
+
+              <!-- Price Range -->
+              <div class="mb-6">
+                <label class="block text-sm font-medium text-gray-700 mb-2">
+                  Price Range
+                </label>
+                <div class="flex gap-2">
+                  <input
+                    type="number"
+                    name="filter[min_price]"
+                    placeholder="Min"
+                    value={@filters.min_price}
+                    class="w-1/2 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                  />
+                  <input
+                    type="number"
+                    name="filter[max_price]"
+                    placeholder="Max"
+                    value={@filters.max_price}
+                    class="w-1/2 px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+                  />
+                </div>
+              </div>
+
+              <!-- Categories -->
+              <div class="mb-6">
+                <label class="block text-sm font-medium text-gray-700 mb-2">
+                  Categories
+                </label>
+                <div class="space-y-2">
+                  <%= for category <- @categories do %>
+                    <label class="flex items-center">
+                      <input
+                        type="checkbox"
+                        name="filter[categories][]"
+                        value={category.id}
+                        checked={category.id in @filters.categories}
+                        class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                      />
+                      <span class="ml-2 text-sm text-gray-700"><%= category.name %></span>
+                    </label>
+                  <% end %>
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                class="w-full px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors"
+              >
+                Apply Filters
+              </button>
+            </form>
+          </div>
+        <% end %>
+      </div>
+
+      <!-- Events Grid/List -->
+      <div class="flex-1">
+        <%= if @view_mode == "grid" do %>
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            <%= for event <- @events do %>
+              <.link navigate={~p"/e/#{event.slug}"} class="block">
+                <div class="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow duration-300">
+                  <div class="aspect-w-16 aspect-h-9 relative">
+                    <%= if event.cover_image_url do %>
+                      <img
+                        src={event.cover_image_url}
+                        alt={event.title}
+                        class="w-full h-48 object-cover"
+                      />
+                    <% else %>
+                      <div class="w-full h-48 bg-gradient-to-br from-indigo-500 to-purple-600"></div>
+                    <% end %>
+                    <%= if event.ticket_url do %>
+                      <div class="absolute top-2 right-2 bg-green-500 text-white px-2 py-1 rounded text-xs font-semibold">
+                        TICKETED
+                      </div>
+                    <% end %>
+                  </div>
+                  <div class="p-4">
+                    <h3 class="font-semibold text-lg mb-2 line-clamp-2">
+                      <%= Map.get(event, :display_title, event.title) %>
+                    </h3>
+                    <div class="text-sm text-gray-600 space-y-1">
+                      <div class="flex items-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                        </svg>
+                        <%= Calendar.strftime(event.start_time, "%b %d, %Y") %>
+                      </div>
+                      <%= if event.venue_name do %>
+                        <div class="flex items-center">
+                          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                          </svg>
+                          <span class="truncate"><%= event.venue_name %></span>
+                        </div>
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+              </.link>
+            <% end %>
+          </div>
+        <% else %>
+          <!-- List View -->
+          <div class="space-y-4">
+            <%= for event <- @events do %>
+              <.link navigate={~p"/e/#{event.slug}"} class="block">
+                <div class="bg-white rounded-lg shadow-md p-4 hover:shadow-xl transition-shadow duration-300">
+                  <div class="flex gap-4">
+                    <%= if event.cover_image_url do %>
+                      <img
+                        src={event.cover_image_url}
+                        alt={event.title}
+                        class="w-24 h-24 object-cover rounded-lg flex-shrink-0"
+                      />
+                    <% else %>
+                      <div class="w-24 h-24 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-lg flex-shrink-0"></div>
+                    <% end %>
+                    <div class="flex-1">
+                      <div class="flex items-start justify-between">
+                        <div>
+                          <h3 class="font-semibold text-lg mb-1">
+                            <%= Map.get(event, :display_title, event.title) %>
+                          </h3>
+                          <div class="text-sm text-gray-600 space-y-1">
+                            <div class="flex items-center">
+                              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                              </svg>
+                              <%= Calendar.strftime(event.start_time, "%B %d, %Y at %I:%M %p") %>
+                            </div>
+                            <%= if event.venue_name do %>
+                              <div class="flex items-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                                </svg>
+                                <%= event.venue_name %>
+                              </div>
+                            <% end %>
+                          </div>
+                        </div>
+                        <%= if event.ticket_url do %>
+                          <span class="bg-green-500 text-white px-2 py-1 rounded text-xs font-semibold">
+                            TICKETED
+                          </span>
+                        <% end %>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </.link>
+            <% end %>
+          </div>
+        <% end %>
+
+        <!-- Pagination -->
+        <%= if @pagination.total_pages > 1 do %>
+          <div class="mt-8 flex justify-center">
+            <nav class="flex items-center space-x-2">
+              <%= if @pagination.current_page > 1 do %>
+                <button
+                  phx-click="paginate"
+                  phx-value-page={@pagination.current_page - 1}
+                  class="px-3 py-2 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+                >
+                  Previous
+                </button>
+              <% end %>
+
+              <%= for page <- 1..@pagination.total_pages do %>
+                <%= if abs(page - @pagination.current_page) < 3 or page == 1 or page == @pagination.total_pages do %>
+                  <button
+                    phx-click="paginate"
+                    phx-value-page={page}
+                    class={"px-3 py-2 rounded-md #{if page == @pagination.current_page, do: "bg-indigo-600 text-white", else: "bg-white border border-gray-300 hover:bg-gray-50"}"}
+                  >
+                    <%= page %>
+                  </button>
+                <% end %>
+                <%= if abs(page - @pagination.current_page) == 3 and page != 1 and page != @pagination.total_pages do %>
+                  <span class="px-2">...</span>
+                <% end %>
+              <% end %>
+
+              <%= if @pagination.current_page < @pagination.total_pages do %>
+                <button
+                  phx-click="paginate"
+                  phx-value-page={@pagination.current_page + 1}
+                  class="px-3 py-2 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+                >
+                  Next
+                </button>
+              <% end %>
+            </nav>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/eventasaurus_web/live/city_live/venues.ex
+++ b/lib/eventasaurus_web/live/city_live/venues.ex
@@ -1,0 +1,12 @@
+defmodule EventasaurusWeb.CityLive.Venues do
+  @moduledoc """
+  LiveView for city venues listing.
+  """
+  use EventasaurusWeb, :live_view
+
+  # Temporary stub - redirects to index
+  @impl true
+  def mount(%{"city_slug" => city_slug}, _session, socket) do
+    {:ok, push_navigate(socket, to: ~p"/c/#{city_slug}")}
+  end
+end

--- a/lib/eventasaurus_web/live/public_events_index_live.ex
+++ b/lib/eventasaurus_web/live/public_events_index_live.ex
@@ -4,6 +4,7 @@ defmodule EventasaurusWeb.PublicEventsIndexLive do
   alias EventasaurusDiscovery.PublicEventsEnhanced
   alias EventasaurusDiscovery.Pagination
   alias EventasaurusDiscovery.Categories
+  alias EventasaurusWeb.Helpers.CategoryHelpers
 
   @impl true
   def mount(_params, _session, socket) do
@@ -631,8 +632,8 @@ defmodule EventasaurusWeb.PublicEventsIndexLive do
           <% end %>
 
           <%= if @event.categories && @event.categories != [] do %>
-            <% category = List.first(@event.categories) %>
-            <%= if category.color do %>
+            <% category = CategoryHelpers.get_preferred_category(@event.categories) %>
+            <%= if category && category.color do %>
               <div
                 class="absolute top-3 left-3 px-2 py-1 rounded-md text-xs font-medium text-white"
                 style={"background-color: #{category.color}"}

--- a/lib/eventasaurus_web/plugs/validate_city.ex
+++ b/lib/eventasaurus_web/plugs/validate_city.ex
@@ -1,0 +1,40 @@
+defmodule EventasaurusWeb.Plugs.ValidateCity do
+  @moduledoc """
+  Plug to validate city slugs in URLs and load the city into the connection.
+
+  This plug is used in the `/c/:city_slug` routes to ensure the city exists
+  and has coordinates before proceeding with the request.
+  """
+
+  import Plug.Conn
+  import Phoenix.Controller
+  alias EventasaurusDiscovery.Locations
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    city_slug = conn.params["city_slug"] || conn.path_params["city_slug"]
+
+    case Locations.get_city_by_slug(city_slug) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> put_view(html: EventasaurusWeb.ErrorHTML)
+        |> render(:"404")
+        |> halt()
+
+      city ->
+        # Check if city has coordinates
+        if city.latitude && city.longitude do
+          assign(conn, :current_city, city)
+        else
+          # City exists but has no coordinates yet
+          conn
+          |> put_status(:service_unavailable)
+          |> put_view(html: EventasaurusWeb.ErrorHTML)
+          |> render(:"503", message: "City location data is being processed. Please try again later.")
+          |> halt()
+        end
+    end
+  end
+end

--- a/lib/mix/tasks/discovery.calculate_city_coordinates.ex
+++ b/lib/mix/tasks/discovery.calculate_city_coordinates.ex
@@ -106,13 +106,7 @@ defmodule Mix.Tasks.Discovery.CalculateCityCoordinates do
   end
 
   defp schedule_calculation(city_id, city_name, force) do
-    args = if force do
-      %{city_id: city_id, force: true}
-    else
-      %{city_id: city_id}
-    end
-
-    case CityCoordinateCalculationJob.new(args) |> Oban.insert() do
+    case CityCoordinateCalculationJob.schedule_update(city_id, force) do
       {:ok, _job} ->
         :scheduled
       {:error, %Ecto.Changeset{errors: [args: {"has already been scheduled", _}]}} ->


### PR DESCRIPTION
new style

Fix city page filters: category filtering now works, radius default fixed

- Fixed category filtering by adding :categories to Map.take in build_filter_params
- Fixed radius filter showing as active when set to default (50km)
- Fixed template crash by using hardcoded value instead of module attribute
- Category filtering now properly filters events (137 → 31 for Theatre)
- URL parameters only include non-default values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced city-scoped pages (/c/:city_slug) for event discovery with search, filters (radius, date, price, categories), sorting, grid/list views, and pagination.
  - Added a dedicated city search page and temporary redirects for events/venues to the city index.
  - Increased event page size limits for richer result sets.

- Bug Fixes
  - Improved category selection to display more accurate badges and reduce “Other” mislabeling.

- Documentation
  - Added a guide outlining current city filtering issues, expected behavior, testing steps, and planned improvements.

- UX
  - Clear responses for unknown cities or cities still processing location data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->