### PR TITLE
hide pricing

### DIFF
--- a/lib/eventasaurus_discovery/public_events/public_event_source.ex
+++ b/lib/eventasaurus_discovery/public_events/public_event_source.ex
@@ -9,6 +9,10 @@ defmodule EventasaurusDiscovery.PublicEvents.PublicEventSource do
     field(:metadata, :map, default: %{})
     field(:description_translations, :map)
     field(:image_url, :string)
+    field(:min_price, :decimal)
+    field(:max_price, :decimal)
+    field(:currency, :string)
+    field(:is_free, :boolean, default: false)
 
     belongs_to(:event, EventasaurusDiscovery.PublicEvents.PublicEvent)
     belongs_to(:source, EventasaurusDiscovery.Sources.Source)
@@ -27,7 +31,11 @@ defmodule EventasaurusDiscovery.PublicEvents.PublicEventSource do
       :last_seen_at,
       :metadata,
       :description_translations,
-      :image_url
+      :image_url,
+      :min_price,
+      :max_price,
+      :currency,
+      :is_free
     ])
     |> validate_required([:event_id, :source_id, :last_seen_at])
     |> foreign_key_constraint(:event_id)

--- a/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
+++ b/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
@@ -84,7 +84,12 @@ defmodule EventasaurusDiscovery.Scraping.Processors.EventProcessor do
       # Add raw data for category extraction
       raw_event_data: data[:raw_event_data] || data["raw_event_data"],
       # Karnet category
-      category: data[:category] || data["category"]
+      category: data[:category] || data["category"],
+      # Price data - now stored at source level
+      min_price: data[:min_price] || data["min_price"],
+      max_price: data[:max_price] || data["max_price"],
+      currency: data[:currency] || data["currency"],
+      is_free: data[:is_free] || data["is_free"]
     }
 
     cond do
@@ -349,7 +354,12 @@ defmodule EventasaurusDiscovery.Scraping.Processors.EventProcessor do
       last_seen_at: DateTime.utc_now() |> DateTime.truncate(:second),
       metadata: metadata,
       description_translations: data.description_translations,
-      image_url: data.image_url
+      image_url: data.image_url,
+      # Add price fields
+      min_price: data[:min_price],
+      max_price: data[:max_price],
+      currency: data[:currency],
+      is_free: data[:is_free] || false
     }
 
     case existing_by_external do
@@ -391,7 +401,12 @@ defmodule EventasaurusDiscovery.Scraping.Processors.EventProcessor do
           metadata: attrs.metadata,
           image_url: attrs.image_url,
           source_url: attrs.source_url,
-          description_translations: attrs.description_translations
+          description_translations: attrs.description_translations,
+          # Add price fields
+          min_price: attrs.min_price,
+          max_price: attrs.max_price,
+          currency: attrs.currency,
+          is_free: attrs.is_free
         })
         |> Repo.update()
 
@@ -1024,6 +1039,11 @@ defmodule EventasaurusDiscovery.Scraping.Processors.EventProcessor do
       image_url: occurrence_data[:image_url] || occurrence_data["image_url"],
       description_translations:
         occurrence_data[:description_translations] || occurrence_data["description_translations"],
+      # Price fields from source data
+      min_price: occurrence_data[:min_price],
+      max_price: occurrence_data[:max_price],
+      currency: occurrence_data[:currency],
+      is_free: occurrence_data[:is_free] || false,
       metadata: %{
         "occurrence" => true,
         "merged_at" => DateTime.utc_now(),

--- a/lib/eventasaurus_discovery/scraping/scrapers/bandsintown/detail_extractor.ex
+++ b/lib/eventasaurus_discovery/scraping/scrapers/bandsintown/detail_extractor.ex
@@ -131,6 +131,10 @@ defmodule EventasaurusDiscovery.Scraping.Scrapers.Bandsintown.DetailExtractor do
   defp extract_ticket_url([]), do: nil
   defp extract_ticket_url([offer | _]), do: offer["url"]
 
+  # NOTE: As of September 2025, Bandsintown's JSON-LD does not include actual price values
+  # in the offers object - only availability status. The price/lowPrice/highPrice fields
+  # are either missing or null. This infrastructure is retained for future API improvements.
+  # See GitHub issue #1281 for details.
   defp extract_min_price([]), do: nil
 
   defp extract_min_price(offers) do

--- a/lib/eventasaurus_web/live/city_live/index.ex
+++ b/lib/eventasaurus_web/live/city_live/index.ex
@@ -498,6 +498,9 @@ defmodule EventasaurusWeb.CityLive.Index do
             </div>
           <% end %>
 
+          <%!-- Price display temporarily hidden - no APIs provide price data
+               Infrastructure retained for future API support
+               See GitHub issue #1281 for details
           <%= if @event.min_price || @event.max_price do %>
             <div class="mt-2">
               <span class="text-sm font-medium text-gray-900">
@@ -506,11 +509,12 @@ defmodule EventasaurusWeb.CityLive.Index do
             </div>
           <% else %>
             <div class="mt-2">
-              <span class="text-sm font-medium text-green-600">
-                Free
+              <span class="text-sm font-medium text-gray-500">
+                Price not available
               </span>
             </div>
           <% end %>
+          --%>
         </div>
       </div>
     </.link>
@@ -594,17 +598,21 @@ defmodule EventasaurusWeb.CityLive.Index do
             <% end %>
           </div>
 
+          <%!-- Price display temporarily hidden - no APIs provide price data
+               Infrastructure retained for future API support
+               See GitHub issue #1281 for details
           <div class="ml-6 text-right">
             <%= if @event.min_price || @event.max_price do %>
               <div class="text-lg font-semibold text-gray-900">
                 <%= format_price_range(@event) %>
               </div>
             <% else %>
-              <div class="text-lg font-semibold text-green-600">
-                Free
+              <div class="text-lg font-semibold text-gray-500">
+                Price not available
               </div>
             <% end %>
           </div>
+          --%>
         </div>
       </div>
     </.link>
@@ -742,7 +750,7 @@ defmodule EventasaurusWeb.CityLive.Index do
         "Up to $#{event.max_price}"
 
       true ->
-        "Free"
+        "Price not available"
     end
   end
 

--- a/lib/eventasaurus_web/live/city_live/search.html.heex
+++ b/lib/eventasaurus_web/live/city_live/search.html.heex
@@ -139,6 +139,9 @@
                 />
               </div>
 
+              <%!-- Price filtering temporarily hidden - no APIs provide price data
+                   Infrastructure retained for future API support
+                   See GitHub issue #1281 for details
               <!-- Price Range -->
               <div class="mb-6">
                 <label class="block text-sm font-medium text-gray-700 mb-2">
@@ -161,6 +164,7 @@
                   />
                 </div>
               </div>
+              --%>
 
               <!-- Categories -->
               <div class="mb-6">

--- a/lib/eventasaurus_web/live/public_event_show_live.ex
+++ b/lib/eventasaurus_web/live/public_event_show_live.ex
@@ -642,6 +642,9 @@ defmodule EventasaurusWeb.PublicEventShowLive do
                     </div>
                   <% end %>
 
+                  <%!-- Price display temporarily hidden - no APIs provide price data
+                       Infrastructure retained for future API support
+                       See GitHub issue #1281 for details
                   <!-- Price -->
                   <div>
                     <div class="flex items-center text-gray-600 mb-1">
@@ -652,6 +655,7 @@ defmodule EventasaurusWeb.PublicEventShowLive do
                       <%= format_price_range(@event) %>
                     </p>
                   </div>
+                  --%>
 
                   <!-- Ticket Link -->
                   <%= if @event.ticket_url do %>

--- a/lib/eventasaurus_web/live/public_events_index_live.ex
+++ b/lib/eventasaurus_web/live/public_events_index_live.ex
@@ -561,6 +561,9 @@ defmodule EventasaurusWeb.PublicEventsIndexLive do
           />
         </div>
 
+        <%!-- Price filtering temporarily hidden - no APIs provide price data
+             Infrastructure retained for future API support
+             See GitHub issue #1281 for details
         <!-- Price Range -->
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-2">
@@ -583,6 +586,7 @@ defmodule EventasaurusWeb.PublicEventsIndexLive do
             />
           </div>
         </div>
+        --%>
 
         <!-- Sort By -->
         <div>
@@ -678,6 +682,9 @@ defmodule EventasaurusWeb.PublicEventsIndexLive do
             </div>
           <% end %>
 
+          <%!-- Price display temporarily hidden - no APIs provide price data
+               Infrastructure retained for future API support
+               See GitHub issue #1281 for details
           <%= if @event.min_price || @event.max_price do %>
             <div class="mt-2">
               <span class="text-sm font-medium text-gray-900">
@@ -686,11 +693,12 @@ defmodule EventasaurusWeb.PublicEventsIndexLive do
             </div>
           <% else %>
             <div class="mt-2">
-              <span class="text-sm font-medium text-green-600">
-                <%= gettext("Free") %>
+              <span class="text-sm font-medium text-gray-500">
+                <%= gettext("Price not available") %>
               </span>
             </div>
           <% end %>
+          --%>
         </div>
       </div>
     </.link>
@@ -774,17 +782,21 @@ defmodule EventasaurusWeb.PublicEventsIndexLive do
             <% end %>
           </div>
 
+          <%!-- Price display temporarily hidden - no APIs provide price data
+               Infrastructure retained for future API support
+               See GitHub issue #1281 for details
           <div class="ml-6 text-right">
             <%= if @event.min_price || @event.max_price do %>
               <div class="text-lg font-semibold text-gray-900">
                 <%= format_price_range(@event) %>
               </div>
             <% else %>
-              <div class="text-lg font-semibold text-green-600">
-                <%= gettext("Free") %>
+              <div class="text-lg font-semibold text-gray-500">
+                <%= gettext("Price not available") %>
               </div>
             <% end %>
           </div>
+          --%>
         </div>
       </div>
     </.link>

--- a/priv/repo/migrations/20250926081436_add_price_columns_to_public_event_sources.exs
+++ b/priv/repo/migrations/20250926081436_add_price_columns_to_public_event_sources.exs
@@ -1,0 +1,25 @@
+defmodule EventasaurusApp.Repo.Migrations.AddPriceColumnsToPublicEventSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:public_event_sources) do
+      add :min_price, :decimal, precision: 10, scale: 2
+      add :max_price, :decimal, precision: 10, scale: 2
+      add :currency, :string, size: 3
+      add :is_free, :boolean, default: false, null: false
+    end
+
+    # Add check constraint to ensure is_free can't be true when prices exist
+    create constraint(:public_event_sources, :is_free_price_consistency,
+      check: "NOT (is_free = true AND (min_price IS NOT NULL OR max_price IS NOT NULL))")
+
+    # Create indexes for price queries
+    create index(:public_event_sources, [:min_price])
+    create index(:public_event_sources, [:max_price])
+    create index(:public_event_sources, [:event_id, :min_price])
+    create index(:public_event_sources, [:is_free])
+
+    # We're not removing columns from public_events yet to maintain backward compatibility
+    # That can be done in a future migration once everything is working
+  end
+end

--- a/priv/repo/migrations/20250926083503_update_public_events_view_for_source_prices.exs
+++ b/priv/repo/migrations/20250926083503_update_public_events_view_for_source_prices.exs
@@ -1,0 +1,146 @@
+defmodule EventasaurusApp.Repo.Migrations.UpdatePublicEventsViewForSourcePrices do
+  use Ecto.Migration
+
+  def up do
+    # Drop the existing view
+    execute "DROP VIEW IF EXISTS public_events_view"
+
+    # Recreate the view with price data coming from public_event_sources
+    execute """
+    CREATE VIEW public_events_view AS
+    SELECT
+      pe.id,
+      pe.slug,
+      pe.title,
+      pe.title_translations,
+      pe.starts_at,
+      pe.ends_at,
+      pe.venue_id,
+      pe.category_id,
+      -- Price fields now come from the source, not the event
+      pes.min_price,
+      pes.max_price,
+      pes.currency,
+      pes.is_free,
+      pe.ticket_url,
+      pe.inserted_at,
+      pe.updated_at,
+      pes.id AS source_id,
+      pes.description_translations,
+      pes.image_url,
+      pes.source_url,
+      pes.external_id,
+      pes.metadata AS source_metadata,
+      pes.last_seen_at AS source_last_seen_at,
+      v.name AS venue_name,
+      v.slug AS venue_slug,
+      v.address AS venue_address,
+      v.latitude AS venue_latitude,
+      v.longitude AS venue_longitude,
+      v.venue_type,
+      c.id AS city_id,
+      c.name AS city_name,
+      c.slug AS city_slug,
+      co.id AS country_id,
+      co.name AS country_name,
+      co.code AS country_code,
+      cat.name AS category_name,
+      cat.slug AS category_slug,
+      cat.translations AS category_translations,
+      cat.icon AS category_icon,
+      cat.color AS category_color
+    FROM public_events pe
+    LEFT JOIN LATERAL (
+      SELECT *
+      FROM public_event_sources
+      WHERE event_id = pe.id
+      ORDER BY
+        COALESCE(
+          CASE
+            WHEN metadata->>'priority' ~ '^[0-9]+$'
+            THEN (metadata->>'priority')::integer
+            ELSE NULL
+          END,
+          10
+        ),
+        last_seen_at DESC
+      LIMIT 1
+    ) pes ON true
+    LEFT JOIN venues v ON pe.venue_id = v.id
+    LEFT JOIN cities c ON v.city_id = c.id
+    LEFT JOIN countries co ON c.country_id = co.id
+    LEFT JOIN categories cat ON pe.category_id = cat.id
+    """
+  end
+
+  def down do
+    # Drop the updated view
+    execute "DROP VIEW IF EXISTS public_events_view"
+
+    # Recreate the original view with prices from public_events
+    execute """
+    CREATE VIEW public_events_view AS
+    SELECT
+      pe.id,
+      pe.slug,
+      pe.title,
+      pe.title_translations,
+      pe.starts_at,
+      pe.ends_at,
+      pe.venue_id,
+      pe.category_id,
+      -- Original: prices from public_events
+      pe.min_price,
+      pe.max_price,
+      pe.currency,
+      pe.ticket_url,
+      pe.inserted_at,
+      pe.updated_at,
+      pes.id AS source_id,
+      pes.description_translations,
+      pes.image_url,
+      pes.source_url,
+      pes.external_id,
+      pes.metadata AS source_metadata,
+      pes.last_seen_at AS source_last_seen_at,
+      v.name AS venue_name,
+      v.slug AS venue_slug,
+      v.address AS venue_address,
+      v.latitude AS venue_latitude,
+      v.longitude AS venue_longitude,
+      v.venue_type,
+      c.id AS city_id,
+      c.name AS city_name,
+      c.slug AS city_slug,
+      co.id AS country_id,
+      co.name AS country_name,
+      co.code AS country_code,
+      cat.name AS category_name,
+      cat.slug AS category_slug,
+      cat.translations AS category_translations,
+      cat.icon AS category_icon,
+      cat.color AS category_color
+    FROM public_events pe
+    LEFT JOIN LATERAL (
+      SELECT *
+      FROM public_event_sources
+      WHERE event_id = pe.id
+      ORDER BY
+        COALESCE(
+          CASE
+            WHEN metadata->>'priority' ~ '^[0-9]+$'
+            THEN (metadata->>'priority')::integer
+            ELSE NULL
+          END,
+          10
+        ),
+        last_seen_at DESC
+      LIMIT 1
+    ) pes ON true
+    LEFT JOIN venues v ON pe.venue_id = v.id
+    LEFT JOIN cities c ON v.city_id = c.id
+    LEFT JOIN countries co ON c.country_id = co.id
+    LEFT JOIN categories cat ON pe.category_id = cat.id
+    """
+  end
+end


### PR DESCRIPTION
### TL;DR

Added price data fields to event sources and updated the data flow to store pricing information at the source level rather than the event level.

### What changed?

- Added price-related fields (`min_price`, `max_price`, `currency`, `is_free`) to the `PublicEventSource` schema
- Updated the event processor to handle price data at the source level
- Added price extraction logic in the Ticketmaster transformer
- Created migrations to add price columns to the `public_event_sources` table
- Updated the `public_events_view` to pull price data from sources instead of events
- Temporarily commented out price display in UI templates since current APIs don't provide reliable price data

### How to test?

1. Run migrations to add the new price columns to the database
2. Verify that scraped events correctly store price information at the source level
3. Confirm that the updated view correctly displays price information from sources
4. Check that the UI correctly handles the absence of price data

### Why make this change?

This change improves our data model by storing price information at the source level, which is more accurate since different sources may report different prices for the same event. The implementation includes infrastructure for future API improvements while acknowledging that current APIs (Bandsintown, Ticketmaster) don't reliably provide price data (as noted in GitHub issue #1281).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
    - Temporarily hide price displays on event cards, lists, and event pages.
    - Replace “Free” labels with “Price not available.”
    - Hide the Price Range filter in search and public event views.
- Chores
    - Backend updated to ingest and store basic price information (min/max, currency, free flag) from event sources.
    - Data view updated to reference source-level prices for future consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->