### PR TITLE
karnet and changes

### DIFF
--- a/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
+++ b/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
@@ -72,9 +72,9 @@ defmodule EventasaurusDiscovery.Scraping.Processors.EventProcessor do
       title_translations: data[:title_translations] || data["title_translations"],
       description_translations:
         data[:description_translations] || data["description_translations"],
-      start_at: parse_datetime(data[:start_at] || data["start_at"]),
+      start_at: parse_datetime(data[:start_at] || data["start_at"] || data[:starts_at] || data["starts_at"]),
       ends_at: parse_datetime(data[:ends_at] || data["ends_at"]),
-      venue_data: data[:venue_data] || data["venue_data"],
+      venue_data: data[:venue_data] || data["venue_data"] || data[:venue] || data["venue"],
       performer_names: data[:performer_names] || data["performer_names"] || [],
       metadata: data[:metadata] || data["metadata"] || %{},
       source_url: data[:source_url] || data["source_url"],

--- a/lib/eventasaurus_discovery/sources/karnet/jobs/sync_job.ex
+++ b/lib/eventasaurus_discovery/sources/karnet/jobs/sync_job.ex
@@ -191,7 +191,8 @@ defmodule EventasaurusDiscovery.Sources.Karnet.Jobs.SyncJob do
         job_args = %{
           "url" => event.url,
           "source_id" => source_id,
-          "event_metadata" => Map.take(event, [:title, :date_text, :venue_name, :category])
+          "event_metadata" => Map.take(event, [:title, :date_text, :venue_name, :category]),
+          "external_id" => extract_external_id_from_url(event.url)
         }
 
         # For now, we'll create a placeholder - EventDetailJob will be implemented in Phase 2
@@ -276,5 +277,14 @@ defmodule EventasaurusDiscovery.Sources.Karnet.Jobs.SyncJob do
     events_per_page = 12
     pages = div(limit, events_per_page)
     if rem(limit, events_per_page) > 0, do: pages + 1, else: pages
+  end
+
+  defp extract_external_id_from_url(url) do
+    # Extract the event ID from the URL
+    # Format: /60682-krakow-event-name
+    case Regex.run(~r/\/(\d+)-/, url) do
+      [_, id] -> "karnet_#{id}"
+      _ -> nil
+    end
   end
 end

--- a/lib/eventasaurus_discovery/sources/ticketmaster/jobs/sync_job.ex
+++ b/lib/eventasaurus_discovery/sources/ticketmaster/jobs/sync_job.ex
@@ -57,8 +57,11 @@ defmodule EventasaurusDiscovery.Sources.Ticketmaster.Jobs.SyncJob do
     # Check if locale was explicitly provided
     case options["locale"] || options[:locale] do
       nil ->
-        # No explicit locale, use country-based detection
-        Config.country_locales(city.country.code)
+        # No explicit locale, use country-based detection with safe fallback
+        case Config.country_locales(city.country.code) do
+          locales when is_list(locales) and locales != [] -> locales
+          _ -> ["en-us"]  # safe fallback if country detection fails
+        end
       locale ->
         # Explicit locale provided, use only that one
         [locale]

--- a/lib/eventasaurus_discovery/sources/ticketmaster/transformer.ex
+++ b/lib/eventasaurus_discovery/sources/ticketmaster/transformer.ex
@@ -38,12 +38,12 @@ defmodule EventasaurusDiscovery.Sources.Ticketmaster.Transformer do
           title: title,
           title_translations: extract_title_translations(title, lang_key),
           description_translations: extract_description_translations(description, lang_key),
-          start_at: parse_event_datetime(tm_event),
+          starts_at: parse_event_datetime(tm_event),
           ends_at: parse_event_end_datetime(tm_event),
           status: map_event_status(tm_event),
           # All Ticketmaster events are ticketed
           is_ticketed: true,
-          venue_data: venue_data,
+          venue: venue_data,
           performers: extract_performers(tm_event),
           # Pass raw event data for category extraction
           raw_event_data: tm_event,


### PR DESCRIPTION
### TL;DR

Added bilingual event support for Karnet events and fixed field name inconsistencies in event processing.

### What changed?

- Enhanced `EventProcessor` to accept alternative field names (`starts_at` in addition to `start_at` and `venue` in addition to `venue_data`)
- Implemented bilingual (Polish/English) content processing for Karnet events:
  - Added functions to extract event IDs from URLs
  - Created logic to fetch and merge content from both language versions
  - Built translation maps for titles and descriptions
- Added external ID extraction and passing in the Karnet sync job
- Added a fallback locale for Ticketmaster when country detection fails

### How to test?

1. Run the Karnet scraper on events that have both Polish and English versions
2. Verify that events are properly processed with bilingual content
3. Check that events from both Karnet and Ticketmaster sources are correctly processed with the alternative field names
4. Verify that Ticketmaster scraper works correctly for countries without explicit locale mappings

### Why make this change?

This change improves the multilingual support of the platform, particularly for events in Krakow that have both Polish and English descriptions. It also makes the event processing more robust by accepting alternative field names, which reduces errors when integrating with different data sources. The Ticketmaster locale fallback ensures the scraper continues to work even when encountering countries without explicit locale mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Bilingual Karnet event processing: automatically merges Polish and English pages for richer titles and descriptions.
  - Enhanced event payload consistency: standardized fields now use starts_at and venue.
- Bug Fixes
  - More robust date and venue detection across sources, reducing missing or incorrect event details.
  - Ticketmaster locale fallback now defaults safely to en-us when country-based locales are unavailable.
- Chores
  - Propagates external_id through sync and detail jobs to support improved cross-language event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->