### PR TITLE
fixes

### DIFF
--- a/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
+++ b/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
@@ -74,7 +74,7 @@ defmodule EventasaurusDiscovery.Scraping.Processors.EventProcessor do
         data[:description_translations] || data["description_translations"],
       start_at: parse_datetime(data[:start_at] || data["start_at"] || data[:starts_at] || data["starts_at"]),
       ends_at: parse_datetime(data[:ends_at] || data["ends_at"]),
-      venue_data: data[:venue_data] || data["venue_data"] || data[:venue] || data["venue"],
+      venue_data: data[:venue_data] || data["venue_data"],
       performer_names: data[:performer_names] || data["performer_names"] || [],
       metadata: data[:metadata] || data["metadata"] || %{},
       source_url: data[:source_url] || data["source_url"],

--- a/lib/eventasaurus_discovery/scraping/scrapers/bandsintown/extractor.ex
+++ b/lib/eventasaurus_discovery/scraping/scrapers/bandsintown/extractor.ex
@@ -198,7 +198,7 @@ defmodule EventasaurusDiscovery.Scraping.Scrapers.Bandsintown.Extractor do
       title: extract_text(document, "h1"),
       description: extract_description(document),
       start_at: extract_datetime(document),
-      venue: extract_venue_info(document),
+      venue_data: extract_venue_info(document),
       performers: extract_performers(document),
       ticket_url: extract_ticket_url(document),
       image_url: extract_image_url(document),

--- a/lib/eventasaurus_discovery/sources/bandsintown/transformer.ex
+++ b/lib/eventasaurus_discovery/sources/bandsintown/transformer.ex
@@ -43,7 +43,7 @@ defmodule EventasaurusDiscovery.Sources.Bandsintown.Transformer do
           ends_at: extract_ends_at(raw_event),
 
           # Venue data - REQUIRED and validated
-          venue: venue_data,
+          venue_data: venue_data,
 
           # Optional fields
           description: extract_description(raw_event),

--- a/lib/eventasaurus_discovery/sources/karnet/jobs/event_detail_job.ex
+++ b/lib/eventasaurus_discovery/sources/karnet/jobs/event_detail_job.ex
@@ -32,8 +32,14 @@ defmodule EventasaurusDiscovery.Sources.Karnet.Jobs.EventDetailJob do
         fallback_to_single_language(url, source_id, event_metadata)
 
       event_id ->
-        Logger.info("🌐 Processing bilingual event ID: #{event_id}")
-        process_bilingual_event(url, event_id, source_id, event_metadata)
+        # Validate that the event ID is numeric
+        if is_binary(event_id) and event_id =~ ~r/^\d+$/ do
+          Logger.info("🌐 Processing bilingual event ID: #{event_id}")
+          process_bilingual_event(url, event_id, source_id, event_metadata)
+        else
+          Logger.warning("Invalid event ID format: #{event_id}, falling back to single language")
+          fallback_to_single_language(url, source_id, event_metadata)
+        end
     end
   end
 
@@ -198,8 +204,6 @@ defmodule EventasaurusDiscovery.Sources.Karnet.Jobs.EventDetailJob do
 
       # Venue - will be processed by VenueProcessor
       venue_data: venue_data,
-      # Alternative key
-      venue: venue_data,
 
       # Performers
       performers: event_data[:performers] || [],

--- a/lib/eventasaurus_discovery/sources/karnet/transformer.ex
+++ b/lib/eventasaurus_discovery/sources/karnet/transformer.ex
@@ -43,7 +43,7 @@ defmodule EventasaurusDiscovery.Sources.Karnet.Transformer do
           ends_at: extract_ends_at(raw_event),
 
           # Venue data - REQUIRED and validated
-          venue: venue_data,
+          venue_data: venue_data,
 
           # Optional fields
           description: extract_description(raw_event),

--- a/lib/eventasaurus_discovery/sources/ticketmaster/transformer.ex
+++ b/lib/eventasaurus_discovery/sources/ticketmaster/transformer.ex
@@ -43,7 +43,7 @@ defmodule EventasaurusDiscovery.Sources.Ticketmaster.Transformer do
           status: map_event_status(tm_event),
           # All Ticketmaster events are ticketed
           is_ticketed: true,
-          venue: venue_data,
+          venue_data: venue_data,
           performers: extract_performers(tm_event),
           # Pass raw event data for category extraction
           raw_event_data: tm_event,


### PR DESCRIPTION
### TL;DR

Standardized venue data field naming from `venue` to `venue_data` across all event processors and transformers.

### What changed?

- Removed the alternative `venue` field from `EventProcessor` to ensure consistent field naming
- Updated Bandsintown extractor to use `venue_data` instead of `venue`
- Updated transformers for Bandsintown, Karnet, and Ticketmaster to use `venue_data` consistently
- Added validation for event ID format in Karnet's `EventDetailJob` with a fallback to single language processing when invalid
- Removed redundant `venue` field in Karnet's `EventDetailJob` event data structure

### How to test?

1. Run the test suite to ensure all event processing still works correctly
2. Test event scraping for Bandsintown, Karnet, and Ticketmaster sources
3. Verify that events are still properly created with venue information
4. Test Karnet scraping with both valid and invalid event IDs to ensure the fallback works

### Why make this change?

This change standardizes the field naming convention across all event processors and transformers, making the codebase more consistent and reducing potential bugs from field name mismatches. The additional validation for Karnet event IDs improves error handling and ensures more robust processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Refactor
  - Standardized event payload to use venue_data instead of venue across all sources for consistent venue handling.

- Bug Fixes
  - Improved robustness of bilingual event processing: non-numeric IDs now log a warning and fall back to single-language processing.
  - Reduced venue parsing ambiguity by sourcing venue details exclusively from venue_data.

- Documentation
  - None

- Chores
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->