### PR TITLE
auth changes

### DIFF
--- a/.env.eventasaurus.example
+++ b/.env.eventasaurus.example
@@ -17,6 +17,13 @@ STRIPE_CONNECT_CLIENT_ID=your_stripe_connect_client_id
 TURNSTILE_SITE_KEY=your_cloudflare_turnstile_site_key
 TURNSTILE_SECRET_KEY=your_cloudflare_turnstile_secret_key
 
+# === Admin Access ===
+# Comma-separated list of admin email addresses (e.g., "admin@example.com,owner@example.com")
+# Users with these emails can access /admin/* routes without needing a separate password
+ADMIN_EMAILS=admin@example.com
+# Legacy: Admin password for Oban dashboard (only used if ADMIN_EMAILS is not set)
+# OBAN_PASSWORD=your_secure_admin_password
+
 # === Maps & Location (Optional) ===
 # Required for event location maps - get from https://account.mapbox.com/
 # SECURITY: Use a PUBLIC token with minimal scopes (styles:read, fonts:read)

--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,11 @@ MISTRAL_API_KEY="your_mistral_key_here"               # Optional, for Mistral AI
 XAI_API_KEY="YOUR_XAI_KEY_HERE"                       # Optional, for xAI AI models.
 AZURE_OPENAI_API_KEY="your_azure_key_here"            # Optional, for Azure OpenAI models (requires endpoint in .taskmasterconfig).
 OLLAMA_API_KEY="your_ollama_api_key_here"             # Optional: For remote Ollama servers that require authentication.
+
+# Admin Configuration
+# Comma-separated list of admin email addresses (e.g., "admin@example.com,owner@example.com")
+# Users with these emails can access /admin/* routes without needing a separate password
+ADMIN_EMAILS=""
+
+# Legacy admin password authentication (fallback if ADMIN_EMAILS is not set)
+# OBAN_PASSWORD=""


### PR DESCRIPTION
### TL;DR

Improved admin access control by adding email-based authentication alongside the existing password method.

### What changed?

- Added `ADMIN_EMAILS` environment variable to both `.env.example` files that accepts a comma-separated list of admin email addresses
- Enhanced the `ObanAuthPlug` to first check if the logged-in user's email is in the admin list before falling back to password authentication
- Improved error messages to be more helpful when neither authentication method is configured
- Maintained backward compatibility with the existing `OBAN_PASSWORD` method

### How to test?

1. Add your email to the `ADMIN_EMAILS` environment variable (e.g., `ADMIN_EMAILS=your@email.com`)
2. Log in with that email address
3. Visit any `/admin/*` route and verify you can access it without a password prompt
4. Test with an unauthorized email to ensure access is denied
5. Remove `ADMIN_EMAILS` and set `OBAN_PASSWORD` to verify the legacy password authentication still works

### Why make this change?

This change simplifies admin access management by allowing specific users to access admin routes based on their email address, eliminating the need to share a common password. It provides a more secure and user-friendly approach while maintaining backward compatibility with the existing password-based authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email-based admin access for /admin routes via configurable ADMIN_EMAILS. Legacy password fallback retained if emails aren’t configured.
* **Documentation**
  * Updated environment examples with guidance on configuring admin access and legacy fallback behavior.
* **Chores**
  * Added ADMIN_EMAILS to environment templates; clarified existing entries with no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->