### PR TITLE
fixes for hardcode

### DIFF
--- a/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
+++ b/lib/eventasaurus_discovery/scraping/processors/event_processor.ex
@@ -16,6 +16,7 @@ defmodule EventasaurusDiscovery.Scraping.Processors.EventProcessor do
   alias EventasaurusDiscovery.Scraping.Helpers.Normalizer
   alias EventasaurusDiscovery.Services.CollisionDetector
   alias EventasaurusDiscovery.Categories.CategoryExtractor
+  alias EventasaurusDiscovery.Sources.Source
   alias Ecto.Multi
 
   import Ecto.Query
@@ -562,19 +563,11 @@ defmodule EventasaurusDiscovery.Scraping.Processors.EventProcessor do
   end
 
   defp process_categories(event, data, source_id) do
-    # Determine source name from source_id
-    # FIXED: Corrected source ID mapping based on actual database IDs
+    # Look up source by ID to get the slug - don't hardcode IDs!
     source_name =
-      case source_id do
-        # ID 1 is Bandsintown (was wrongly "ticketmaster")
-        1 -> "bandsintown"
-        # ID 2 is Ticketmaster (was wrongly "karnet")
-        2 -> "ticketmaster"
-        # ID 3 is StubHub (not currently used)
-        3 -> "stubhub"
-        # ID 4 is Karnet (was wrongly ID 2)
-        4 -> "karnet"
-        _ -> "unknown"
+      case Repo.get(Source, source_id) do
+        nil -> "unknown"
+        source -> source.slug
       end
 
     # Extract and assign categories based on source


### PR DESCRIPTION
### TL;DR

Replaced hardcoded source ID to name mapping with a database lookup.

### What changed?

Modified the `process_categories` function to look up the source by ID in the database instead of using a hardcoded mapping of IDs to source names. This change:

- Adds an alias for `EventasaurusDiscovery.Sources.Source`
- Replaces the case statement that mapped IDs to hardcoded strings with a database query
- Uses the source's `slug` field from the database record

### How to test?

1. Verify that events are correctly processed with the appropriate source name
2. Test with various source IDs to ensure the correct slug is retrieved
3. Test with an invalid source ID to confirm it falls back to "unknown"

### Why make this change?

The previous implementation used hardcoded ID-to-name mappings which were prone to errors (as noted in the comments) and would break if source IDs changed. This approach is more maintainable as it dynamically fetches the source information from the database, eliminating the need to update code when sources change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved event categorization across sources, reducing misclassified or “unknown” categories.
    - Better handling of newly added sources without manual updates.
- **Refactor**
    - Replaced hardcoded source mappings with a dynamic lookup to ensure more consistent category assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->