### PR TITLE
small

### DIFF
--- a/lib/eventasaurus_web/live/helpers/event_filters.ex
+++ b/lib/eventasaurus_web/live/helpers/event_filters.ex
@@ -1,6 +1,6 @@
 defmodule EventasaurusWeb.Live.Helpers.EventFilters do
   @moduledoc """
-  Shared event filtering logic for City and Activities pages.
+  Shared event filtering logic for City and Public Events pages.
 
   This module provides pure functions for transforming filter maps,
   calculating active filter counts, and managing date range filters.
@@ -133,13 +133,17 @@ defmodule EventasaurusWeb.Live.Helpers.EventFilters do
     # Custom date range - format the dates
     cond do
       filters[:start_date] && filters[:end_date] ->
-        "#{Date.to_string(filters[:start_date])} - #{Date.to_string(filters[:end_date])}"
+        start_str = filters[:start_date] |> DateTime.to_date() |> Date.to_string()
+        end_str = filters[:end_date] |> DateTime.to_date() |> Date.to_string()
+        "#{start_str} - #{end_str}"
 
       filters[:start_date] ->
-        "From #{Date.to_string(filters[:start_date])}"
+        date_str = filters[:start_date] |> DateTime.to_date() |> Date.to_string()
+        "From #{date_str}"
 
       filters[:end_date] ->
-        "Until #{Date.to_string(filters[:end_date])}"
+        date_str = filters[:end_date] |> DateTime.to_date() |> Date.to_string()
+        "Until #{date_str}"
 
       true ->
         "Date Filter"


### PR DESCRIPTION
### TL;DR

Fixed date filter display to properly handle DateTime values in event filters.

### What changed?

- Updated module documentation to reference "Public Events" instead of "Activities" pages
- Modified the date filter display logic to convert DateTime values to Date before string conversion
- Added explicit conversion steps for start and end dates in all date filter conditions

### How to test?

1. Navigate to City or Public Events pages
2. Apply date filters with various combinations of start and end dates
3. Verify that the date filter displays correctly without errors
4. Check that DateTime values are properly formatted as dates in the filter display

### Why make this change?

The previous implementation assumed that `filters[:start_date]` and `filters[:end_date]` were always Date objects, but they could sometimes be DateTime objects. This was causing errors when trying to display date filters. The fix ensures proper type conversion before string formatting.