### PR TITLE
Fix case-insensitive 'Other' category comparison

### DIFF
--- a/lib/eventasaurus_web/helpers/category_helpers.ex
+++ b/lib/eventasaurus_web/helpers/category_helpers.ex
@@ -105,7 +105,14 @@ defmodule EventasaurusWeb.Helpers.CategoryHelpers do
           nil
         end
 
-      name == "Other" || is_nil(name)
+      # Normalize to lowercase to match get_preferred_category/1 behavior
+      downcased =
+        case name do
+          nil -> nil
+          value -> String.downcase(value)
+        end
+
+      downcased == "other" || is_nil(downcased)
     end)
   end
 end


### PR DESCRIPTION
Make only_other_categories?/1 use case-insensitive comparison to match get_preferred_category/1 behavior. This ensures consistency when external feeds send 'other', 'OTHER', or 'Other'.