### PR TITLE
technical debt again virtual

### DIFF
--- a/priv/repo/migrations/20251004114712_add_not_null_to_venue_coordinates.exs
+++ b/priv/repo/migrations/20251004114712_add_not_null_to_venue_coordinates.exs
@@ -18,7 +18,7 @@ defmodule EventasaurusApp.Repo.Migrations.AddNotNullToVenueCoordinates do
 
     # Add NOT NULL constraints for latitude and longitude
     # This enforces data integrity at the database level
-    # All venues (including future online/tbd types) will require coordinates
+    # All venues are physical locations and require coordinates
     alter table(:venues) do
       modify :latitude, :float, null: false
       modify :longitude, :float, null: false

--- a/test/eventasaurus_app/venues/venue_validation_test.exs
+++ b/test/eventasaurus_app/venues/venue_validation_test.exs
@@ -17,32 +17,6 @@ defmodule EventasaurusApp.Venues.VenueValidationTest do
       assert {:longitude, {"GPS coordinates are required for physical venues", []}} in changeset.errors
     end
 
-    test "allows online venues without coordinates (application level)" do
-      # Note: While this passes application validation, the database-level
-      # NOT NULL constraint will prevent actual insertion without coordinates
-      changeset =
-        Venue.changeset(%Venue{}, %{
-          name: "Online Venue",
-          venue_type: "online",
-          source: "user"
-        })
-
-      assert changeset.valid?
-    end
-
-    test "allows tbd venues without coordinates (application level)" do
-      # Note: While this passes application validation, the database-level
-      # NOT NULL constraint will prevent actual insertion without coordinates
-      changeset =
-        Venue.changeset(%Venue{}, %{
-          name: "TBD Venue",
-          venue_type: "tbd",
-          source: "user"
-        })
-
-      assert changeset.valid?
-    end
-
     test "accepts valid coordinates" do
       changeset =
         Venue.changeset(%Venue{}, %{
@@ -143,6 +117,66 @@ defmodule EventasaurusApp.Venues.VenueValidationTest do
 
       assert venue.latitude == 50.0619
       assert venue.longitude == 19.9368
+    end
+
+    test "city venues require coordinates" do
+      changeset =
+        Venue.changeset(%Venue{}, %{
+          name: "San Francisco",
+          venue_type: "city",
+          source: "user"
+        })
+
+      refute changeset.valid?
+      assert {:latitude, {"GPS coordinates are required for physical venues", []}} in changeset.errors
+      assert {:longitude, {"GPS coordinates are required for physical venues", []}} in changeset.errors
+    end
+
+    test "region venues require coordinates" do
+      changeset =
+        Venue.changeset(%Venue{}, %{
+          name: "Bay Area",
+          venue_type: "region",
+          source: "user"
+        })
+
+      refute changeset.valid?
+      assert {:latitude, {"GPS coordinates are required for physical venues", []}} in changeset.errors
+      assert {:longitude, {"GPS coordinates are required for physical venues", []}} in changeset.errors
+    end
+
+    test "city venues accept valid coordinates" do
+      {:ok, venue} =
+        %Venue{}
+        |> Venue.changeset(%{
+          name: "San Francisco",
+          venue_type: "city",
+          source: "user",
+          latitude: 37.7749,
+          longitude: -122.4194
+        })
+        |> Repo.insert()
+
+      assert venue.venue_type == "city"
+      assert venue.latitude == 37.7749
+      assert venue.longitude == -122.4194
+    end
+
+    test "region venues accept valid coordinates" do
+      {:ok, venue} =
+        %Venue{}
+        |> Venue.changeset(%{
+          name: "Bay Area",
+          venue_type: "region",
+          source: "user",
+          latitude: 37.8,
+          longitude: -122.4
+        })
+        |> Repo.insert()
+
+      assert venue.venue_type == "region"
+      assert venue.latitude == 37.8
+      assert venue.longitude == -122.4
     end
   end
 end


### PR DESCRIPTION
### TL;DR

Removed "online" and "tbd" venue types, enforcing that all venues must have GPS coordinates.

### What changed?

- Added comprehensive module documentation explaining venue types and how to handle virtual events
- Removed "online" and "tbd" from valid venue types list
- Modified validation logic to require GPS coordinates for all venue types
- Updated venue type options in the UI dropdown
- Added additional tests for city and region venue types
- Clarified that virtual events should use `Event.is_virtual = true` and `Event.virtual_venue_url` instead of creating venue records

### How to test?

1. Verify that creating venues requires GPS coordinates for all venue types
2. Confirm that only "venue", "city", and "region" appear in venue type dropdown
3. Test creating virtual events using `Event.is_virtual = true` and `Event.virtual_venue_url`
4. Ensure existing tests pass with the updated validation rules

### Why make this change?

This change improves data consistency by ensuring all venue records represent physical locations with valid coordinates. It separates the concept of virtual events from physical venues, making the data model more accurate. Virtual events are now properly handled through dedicated fields on the Event model rather than creating special venue types, which aligns better with the application's domain model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized venue validation: all venues now require latitude and longitude.
- Changes
  - Simplified venue types to “venue”, “city”, and “region”; “online” and “tbd” are no longer valid venue types.
- Documentation
  - Clarified that virtual events should be marked via event settings rather than creating a venue.
- Tests
  - Updated tests to enforce coordinate requirements for city and region venues and remove legacy cases allowing missing coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->