### PR TITLE
metadata

### DIFF
--- a/lib/eventasaurus_app/venues/venue.ex
+++ b/lib/eventasaurus_app/venues/venue.ex
@@ -107,6 +107,7 @@ defmodule EventasaurusApp.Venues.Venue do
     field(:venue_type, :string, default: "venue")
     field(:place_id, :string)
     field(:source, :string, default: "user")
+    field(:google_places_metadata, :map)
 
     belongs_to(:city_ref, EventasaurusDiscovery.Locations.City, foreign_key: :city_id)
     has_many(:events, EventasaurusApp.Events.Event)
@@ -132,7 +133,8 @@ defmodule EventasaurusApp.Venues.Venue do
       :venue_type,
       :place_id,
       :source,
-      :city_id
+      :city_id,
+      :google_places_metadata
     ])
     |> validate_required_by_type()
     |> validate_inclusion(:venue_type, @valid_venue_types,

--- a/priv/repo/migrations/20251004205529_add_google_places_metadata_to_venues.exs
+++ b/priv/repo/migrations/20251004205529_add_google_places_metadata_to_venues.exs
@@ -1,0 +1,9 @@
+defmodule EventasaurusApp.Repo.Migrations.AddGooglePlacesMetadataToVenues do
+  use Ecto.Migration
+
+  def change do
+    alter table(:venues) do
+      add :google_places_metadata, :map
+    end
+  end
+end


### PR DESCRIPTION
### TL;DR

Added Google Places metadata storage to venues to preserve additional place details.

### What changed?

- Added a new `google_places_metadata` field of type `:map` to the `Venue` schema
- Created a migration to add this column to the venues table
- Updated the venue processor to store the full Google Places details response in this field
- Modified the venue changeset to include the new field

### How to test?

1. Run the migration to add the new column to the venues table
2. Create or update a venue through the scraper that uses Google Places lookup
3. Verify that the Google Places metadata is stored in the database
4. Check that the venue details include the additional metadata from Google Places

### Why make this change?

Google Places API returns rich metadata about venues (such as opening hours, photos, reviews, etc.) that was previously discarded after extracting just the basic location information. Storing this metadata allows us to:

1. Enhance venue details with additional information from Google
2. Reduce the need for repeated API calls to Google Places
3. Build more features using this data in the future without additional API costs

This change preserves all the valuable data we receive from Google Places while maintaining backward compatibility with existing code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
    - Venues now capture and store Google Places metadata, enabling richer venue profiles and improved accuracy in location details during creation and updates.
- Chores
    - Database updated to include a metadata field for storing Google Places information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->