### PR TITLE
name change

### DIFF
--- a/lib/eventasaurus_app/venues/venue.ex
+++ b/lib/eventasaurus_app/venues/venue.ex
@@ -107,7 +107,7 @@ defmodule EventasaurusApp.Venues.Venue do
     field(:venue_type, :string, default: "venue")
     field(:place_id, :string)
     field(:source, :string, default: "user")
-    field(:google_places_metadata, :map)
+    field(:metadata, :map)
 
     belongs_to(:city_ref, EventasaurusDiscovery.Locations.City, foreign_key: :city_id)
     has_many(:events, EventasaurusApp.Events.Event)
@@ -134,7 +134,7 @@ defmodule EventasaurusApp.Venues.Venue do
       :place_id,
       :source,
       :city_id,
-      :google_places_metadata
+      :metadata
     ])
     |> validate_required_by_type()
     |> validate_inclusion(:venue_type, @valid_venue_types,

--- a/lib/eventasaurus_discovery/scraping/processors/venue_processor.ex
+++ b/lib/eventasaurus_discovery/scraping/processors/venue_processor.ex
@@ -467,7 +467,7 @@ defmodule EventasaurusDiscovery.Scraping.Processors.VenueProcessor do
       place_id: final_place_id,
       source: "scraper",
       city_id: city.id,
-      google_places_metadata: google_metadata
+      metadata: google_metadata
     }
 
     case Venue.changeset(%Venue{}, attrs) |> Repo.insert() do

--- a/priv/repo/migrations/20251004205529_add_google_places_metadata_to_venues.exs
+++ b/priv/repo/migrations/20251004205529_add_google_places_metadata_to_venues.exs
@@ -1,9 +1,9 @@
-defmodule EventasaurusApp.Repo.Migrations.AddGooglePlacesMetadataToVenues do
+defmodule EventasaurusApp.Repo.Migrations.AddMetadataToVenues do
   use Ecto.Migration
 
   def change do
     alter table(:venues) do
-      add :google_places_metadata, :map
+      add :metadata, :map
     end
   end
 end


### PR DESCRIPTION
### TL;DR

Renamed the `google_places_metadata` field to `metadata` in the Venue schema to make it more generic.

### What changed?

- Renamed the `google_places_metadata` field to `metadata` in the Venue schema
- Updated the migration file name to reflect the more generic field name
- Updated all references to this field in the codebase, including in the venue processor

### How to test?

1. Run the migrations to ensure the database schema updates correctly
2. Create or update a venue with metadata and verify it saves properly
3. Verify that existing venue data with Google Places metadata is still accessible through the new field name

### Why make this change?

The more generic field name `metadata` allows for storing various types of metadata beyond just Google Places data. This provides flexibility to include metadata from other sources in the future without requiring additional schema changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized venue metadata naming across the app for consistency.
- Chores
  - Updated database column and related data processing to align with the new metadata naming.
- Notes
  - No user-facing functionality changes expected; improves internal consistency and future-proofing of venue data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->