### PR TITLE
venue problems

### DIFF
--- a/priv/repo/migrations/20251005090228_add_unique_constraint_to_venue_place_id.exs
+++ b/priv/repo/migrations/20251005090228_add_unique_constraint_to_venue_place_id.exs
@@ -1,0 +1,43 @@
+defmodule EventasaurusApp.Repo.Migrations.AddUniqueConstraintToVenuePlaceId do
+  use Ecto.Migration
+
+  def up do
+    # CRITICAL: Clean up duplicate venues BEFORE adding unique constraint
+    # This fixes the race condition bug that created 70% duplicates (issue #1492)
+
+    execute """
+    -- Delete duplicate venues (keeping oldest record per place_id)
+    -- All duplicates are orphaned (no events linked), safe to delete
+    WITH duplicates AS (
+      SELECT
+        id,
+        place_id,
+        ROW_NUMBER() OVER (PARTITION BY place_id ORDER BY inserted_at ASC) as rn
+      FROM venues
+      WHERE place_id IS NOT NULL
+    )
+    DELETE FROM venues
+    WHERE id IN (
+      SELECT id FROM duplicates WHERE rn > 1
+    );
+    """
+
+    # Drop the old non-unique index
+    drop_if_exists index(:venues, [:place_id], name: :venues_place_id_index)
+
+    # Create partial unique index (only for non-null place_ids)
+    # This allows multiple NULL place_ids (venues without Google Places lookup)
+    # but enforces uniqueness for all non-null values
+    create unique_index(:venues, [:place_id],
+      where: "place_id IS NOT NULL",
+      name: :venues_place_id_unique_index
+    )
+  end
+
+  def down do
+    # Rollback: restore non-unique index
+    drop_if_exists index(:venues, [:place_id], name: :venues_place_id_unique_index)
+
+    create index(:venues, [:place_id], name: :venues_place_id_index)
+  end
+end


### PR DESCRIPTION
### TL;DR

Fix venue duplication issue by adding a unique constraint on place_id and implementing a race condition check.

### What changed?

- Added a database migration that creates a unique constraint on the `place_id` column in the venues table
- Implemented a cleanup process in the migration to remove existing duplicate venues (keeping the oldest record)
- Added a race condition check in `VenueProcessor` that verifies if a venue with the same place_id already exists before insertion
- Extracted venue insertion logic into a separate `insert_new_venue/6` function

### How to test?

1. Run the migration to clean up existing duplicates and add the unique constraint
2. Test venue creation with parallel workers to verify no duplicates are created
3. Verify that venues with NULL place_ids can still be created without constraint violations

### Why make this change?

This fixes issue #1492 where a race condition was causing duplicate venue records (approximately 70% duplicates) when multiple Oban workers processed the same venue in parallel. The unique constraint at the database level provides a final safeguard, while the application-level check helps avoid unnecessary database errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
    - Eliminates duplicate venue entries caused by parallel processing, reusing existing records when detected.
    - Results in cleaner search/browse lists and more consistent venue details.
- Chores
    - Added a database uniqueness constraint to prevent future duplicate venues while allowing unknown IDs.
    - Cleaned up historical duplicates during migration to improve data integrity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->