### PR TITLE
movie layout

### DIFF
--- a/lib/eventasaurus_web/components/events/occurrence_display.ex
+++ b/lib/eventasaurus_web/components/events/occurrence_display.ex
@@ -151,17 +151,17 @@ defmodule EventasaurusWeb.Components.Events.OccurrenceDisplay do
       is_pattern_occurrence?(occurrences) ->
         :recurring_pattern
 
-      # Movies with many showtimes - use showtime selector
-      is_movie_screening && length(occurrences) > 10 ->
+      # All on same day - time selection
+      all_same_day?(occurrences) ->
+        :same_day_multiple
+
+      # Movies spanning multiple days - use showtime selector
+      is_movie_screening && !all_same_day?(occurrences) ->
         :daily_show
 
       # More than 20 dates for any event - daily show
       length(occurrences) > 20 ->
         :daily_show
-
-      # All on same day - time selection
-      all_same_day?(occurrences) ->
-        :same_day_multiple
 
       # Default - multi day
       true ->

--- a/lib/eventasaurus_web/router.ex
+++ b/lib/eventasaurus_web/router.ex
@@ -457,6 +457,7 @@ defmodule EventasaurusWeb.Router do
       live "/activities/search", PublicEventsIndexLive, :search
       live "/activities/category/:category", PublicEventsIndexLive, :category
       live "/activities/:slug", PublicEventShowLive, :show
+      live "/activities/:slug/:date_slug", PublicEventShowLive, :show
 
       # Guest-accessible checkout
       live "/events/:slug/checkout", CheckoutLive


### PR DESCRIPTION
### TL;DR

Added shareable date-specific URLs for event pages with a simplified URL format.

### What changed?

- Implemented date-specific URLs for event pages in the format `/activities/{slug}/{date-slug}`
- Created a new URL format (`oct-10`) while maintaining backward compatibility with older formats
- Added URL slug parsing and generation functions to handle various date formats
- Updated the router to support the new URL pattern
- Modified the date selection logic to update the URL when a date is selected
- Reordered the occurrence display logic to prioritize same-day events over movie screenings

### How to test?

1. Navigate to an event page with multiple dates
2. Select a specific date from the date picker
3. Verify the URL updates to include the date (e.g., `/activities/event-name/oct-10`)
4. Copy and share this URL, then verify it loads the event with the correct date selected
5. Test with different event types (movies, multi-day events, same-day events)
6. Try older URL formats to ensure backward compatibility

### Why make this change?

This change enables users to share links to events on specific dates, improving the user experience when sharing event information. The simplified URL format is more user-friendly and readable while maintaining compatibility with existing URLs. This is particularly useful for events with multiple occurrences where users want to direct others to a specific date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
    - Navigate directly to a specific show date via URLs that include a date slug (e.g., /activities/:slug/:date_slug).
    - Selecting a show date now updates the URL for easy sharing and bookmarking.
    - Robust handling of various date slug formats with graceful fallbacks for invalid links.
    - Improved showtime display for movie screenings: clearer grouping and selection when all showtimes fall on the same day versus spanning multiple days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->