### PR TITLE
last rabbitzy

### DIFF
--- a/lib/eventasaurus_discovery/performers/performer.ex
+++ b/lib/eventasaurus_discovery/performers/performer.ex
@@ -17,6 +17,7 @@ defmodule EventasaurusDiscovery.Performers.Performer do
 
     many_to_many(:public_events, EventasaurusDiscovery.PublicEvents.PublicEvent,
       join_through: EventasaurusDiscovery.PublicEvents.PublicEventPerformer,
+      join_keys: [performer_id: :id, event_id: :id],
       on_replace: :delete
     )
 

--- a/lib/eventasaurus_discovery/sources/resident_advisor/jobs/artist_enrichment_job.ex
+++ b/lib/eventasaurus_discovery/sources/resident_advisor/jobs/artist_enrichment_job.ex
@@ -64,7 +64,8 @@ defmodule EventasaurusDiscovery.Sources.ResidentAdvisor.Jobs.ArtistEnrichmentJob
   @doc """
   Enrich all performers with RA artist IDs that need enrichment.
 
-  Returns count of jobs scheduled.
+  Returns `{:ok, count}` on success or `{:error, :enqueue_failed}` if any job fails to enqueue.
+  Stops at the first failure to prevent partial batch execution.
   """
   def enrich_all_pending do
     performers = find_performers_needing_enrichment()

--- a/lib/eventasaurus_web/components/country_flag.ex
+++ b/lib/eventasaurus_web/components/country_flag.ex
@@ -1,0 +1,51 @@
+defmodule EventasaurusWeb.Components.CountryFlag do
+  use Phoenix.Component
+
+  @doc """
+  Renders a country flag emoji based on country code.
+
+  ## Examples
+
+      <CountryFlag.flag country_code="US" />
+      <CountryFlag.flag country_code="GB" size="lg" />
+  """
+  attr :country_code, :string, required: true
+  attr :size, :string, default: "md"
+  attr :class, :string, default: ""
+
+  def flag(assigns) do
+    size_class =
+      case assigns.size do
+        "sm" -> "text-base"
+        "md" -> "text-xl"
+        "lg" -> "text-2xl"
+        "xl" -> "text-3xl"
+        _ -> "text-xl"
+      end
+
+    assigns = assign(assigns, :size_class, size_class)
+    assigns = assign(assigns, :flag_emoji, country_code_to_flag(assigns.country_code))
+
+    ~H"""
+    <span class={["inline-block", @size_class, @class]} title={@country_code}>
+      <%= @flag_emoji %>
+    </span>
+    """
+  end
+
+  # Convert country code to flag emoji
+  # Uses Unicode regional indicator symbols
+  defp country_code_to_flag(country_code) when is_binary(country_code) do
+    country_code
+    |> String.upcase()
+    |> String.to_charlist()
+    |> Enum.map(fn char ->
+      # Regional indicator symbols start at 0x1F1E6 (A)
+      # Add 0x1F1E6 - ?A to get the correct offset
+      char + 0x1F1E6 - ?A
+    end)
+    |> List.to_string()
+  end
+
+  defp country_code_to_flag(_), do: "🏳️"
+end

--- a/lib/eventasaurus_web/live/performer_live/show.ex
+++ b/lib/eventasaurus_web/live/performer_live/show.ex
@@ -1,0 +1,332 @@
+defmodule EventasaurusWeb.PerformerLive.Show do
+  use EventasaurusWeb, :live_view
+
+  alias EventasaurusDiscovery.Performers.PerformerStore
+  alias EventasaurusWeb.Components.CountryFlag
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:performer, nil)
+      |> assign(:loading, true)
+      |> assign(:stats, %{})
+      |> assign(:upcoming_events, [])
+      |> assign(:past_events, [])
+      |> assign(:show_past_events, false)
+      |> assign(:past_events_page, 1)
+      |> assign(:past_events_per_page, 10)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"slug" => slug}, _url, socket) do
+    case PerformerStore.get_performer_by_slug(slug) do
+      nil ->
+        {:noreply,
+         socket
+         |> put_flash(:error, gettext("Performer not found"))
+         |> push_navigate(to: ~p"/")}
+
+      performer ->
+        # Get stats and events
+        stats = PerformerStore.get_performer_stats(performer.id)
+        events = PerformerStore.get_performer_events(performer.id)
+
+        socket =
+          socket
+          |> assign(:performer, performer)
+          |> assign(:stats, stats)
+          |> assign(:upcoming_events, events.upcoming)
+          |> assign(:past_events, events.past)
+          |> assign(:loading, false)
+          |> assign(:page_title, performer.name)
+
+        {:noreply, socket}
+    end
+  end
+
+  @impl true
+  def handle_event("toggle_past_events", _params, socket) do
+    {:noreply, assign(socket, :show_past_events, !socket.assigns.show_past_events)}
+  end
+
+  @impl true
+  def handle_event("load_more_past", _params, socket) do
+    {:noreply, update(socket, :past_events_page, &(&1 + 1))}
+  end
+
+  # Helper functions
+
+  defp ra_artist_url(performer) do
+    get_in(performer.metadata, ["ra_artist_url"])
+  end
+
+  defp performer_country(performer) do
+    get_in(performer.metadata, ["country"])
+  end
+
+  defp performer_country_code(performer) do
+    get_in(performer.metadata, ["country_code"])
+  end
+
+  defp performer_source(performer) do
+    get_in(performer.metadata, ["source"]) || "unknown"
+  end
+
+  defp format_date(nil), do: gettext("Unknown")
+
+  defp format_date(%DateTime{} = datetime) do
+    Calendar.strftime(datetime, "%B %d, %Y")
+  end
+
+  defp format_date(%Date{} = date) do
+    Calendar.strftime(date, "%B %d, %Y")
+  end
+
+  defp paginated_past_events(past_events, page, per_page) do
+    past_events
+    |> Enum.reverse()
+    |> Enum.take(page * per_page)
+  end
+
+  defp has_more_past_events?(past_events, page, per_page) do
+    length(past_events) > page * per_page
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="min-h-screen bg-gray-50">
+      <%= if @loading do %>
+        <div class="flex justify-center items-center min-h-screen">
+          <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
+        </div>
+      <% else %>
+        <div class="max-w-6xl mx-auto px-4 py-8">
+          <!-- Performer Header -->
+          <div class="bg-white rounded-lg shadow-md p-8 mb-8">
+            <div class="flex flex-col md:flex-row gap-6 items-start">
+              <!-- Performer Image -->
+              <div class="flex-shrink-0">
+                <%= if @performer.image_url do %>
+                  <img
+                    src={@performer.image_url}
+                    alt={@performer.name}
+                    class="w-48 h-48 rounded-lg object-cover shadow-lg"
+                  />
+                <% else %>
+                  <div class="w-48 h-48 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center shadow-lg">
+                    <span class="text-6xl text-white font-bold">
+                      <%= String.first(@performer.name) %>
+                    </span>
+                  </div>
+                <% end %>
+              </div>
+
+              <!-- Performer Info -->
+              <div class="flex-1">
+                <div class="flex items-center gap-3 mb-2">
+                  <h1 class="text-4xl font-bold text-gray-900">
+                    <%= @performer.name %>
+                  </h1>
+                  <%= if performer_country_code(@performer) do %>
+                    <CountryFlag.flag country_code={performer_country_code(@performer)} size="lg" />
+                  <% end %>
+                </div>
+
+                <%= if performer_country(@performer) do %>
+                  <p class="text-lg text-gray-600 mb-4">
+                    <span class="inline-flex items-center">
+                      <svg
+                        class="w-5 h-5 mr-2"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                        />
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                        />
+                      </svg>
+                      <%= performer_country(@performer) %>
+                    </span>
+                  </p>
+                <% end %>
+
+                <!-- External Links -->
+                <div class="flex gap-3 mt-4">
+                  <%= if ra_artist_url(@performer) do %>
+                    <a
+                      href={ra_artist_url(@performer)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="inline-flex items-center px-4 py-2 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors"
+                    >
+                      <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M12 2L2 7v10c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-10-5z" />
+                      </svg>
+                      Resident Advisor
+                    </a>
+                  <% end %>
+                </div>
+
+                <!-- Source Attribution -->
+                <p class="text-sm text-gray-500 mt-4">
+                  <%= gettext("Data source") %>: <%= performer_source(@performer) %>
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Quick Stats Bar -->
+          <div class="bg-white rounded-lg shadow-md p-6 mb-8">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <div class="text-center">
+                <div class="text-3xl font-bold text-indigo-600">
+                  <%= @stats.total_events %>
+                </div>
+                <div class="text-sm text-gray-600 mt-1">
+                  <%= gettext("Total Events") %>
+                </div>
+              </div>
+
+              <div class="text-center">
+                <div class="text-xl font-semibold text-gray-800">
+                  <%= format_date(@stats.first_event) %>
+                </div>
+                <div class="text-sm text-gray-600 mt-1">
+                  <%= gettext("First Event") %>
+                </div>
+              </div>
+
+              <div class="text-center">
+                <div class="text-xl font-semibold text-gray-800">
+                  <%= format_date(@stats.latest_event) %>
+                </div>
+                <div class="text-sm text-gray-600 mt-1">
+                  <%= gettext("Latest Event") %>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Upcoming Events -->
+          <div class="bg-white rounded-lg shadow-md p-8 mb-8">
+            <h2 class="text-2xl font-bold text-gray-900 mb-6">
+              <%= gettext("Upcoming Events") %>
+            </h2>
+
+            <%= if Enum.empty?(@upcoming_events) do %>
+              <p class="text-gray-600 text-center py-8">
+                <%= gettext("No upcoming events scheduled") %>
+              </p>
+            <% else %>
+              <div class="space-y-4">
+                <%= for event <- Enum.take(@upcoming_events, 10) do %>
+                  <a
+                    href={~p"/activities/#{event.slug}"}
+                    class="block p-4 border border-gray-200 rounded-lg hover:border-indigo-500 hover:shadow-md transition-all"
+                  >
+                    <div class="flex justify-between items-start">
+                      <div class="flex-1">
+                        <h3 class="text-lg font-semibold text-gray-900 mb-1">
+                          <%= event.title %>
+                        </h3>
+                        <%= if event.venue && event.venue.city_ref do %>
+                          <p class="text-sm text-gray-600">
+                            <%= event.venue.city_ref.name %>
+                          </p>
+                        <% end %>
+                      </div>
+                      <div class="text-right ml-4">
+                        <div class="text-sm font-medium text-indigo-600">
+                          <%= format_date(event.starts_at) %>
+                        </div>
+                      </div>
+                    </div>
+                  </a>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+
+          <!-- Past Events (Collapsible) -->
+          <%= if not Enum.empty?(@past_events) do %>
+            <div class="bg-white rounded-lg shadow-md p-8">
+              <button
+                phx-click="toggle_past_events"
+                class="w-full flex justify-between items-center text-left"
+              >
+                <h2 class="text-2xl font-bold text-gray-900">
+                  <%= gettext("Past Events") %> (<%= length(@past_events) %>)
+                </h2>
+                <svg
+                  class={"w-6 h-6 transition-transform #{if @show_past_events, do: "rotate-180", else: ""}"}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </button>
+
+              <%= if @show_past_events do %>
+                <div class="mt-6 space-y-4">
+                  <%= for event <- paginated_past_events(@past_events, @past_events_page, @past_events_per_page) do %>
+                    <a
+                      href={~p"/activities/#{event.slug}"}
+                      class="block p-4 border border-gray-200 rounded-lg hover:border-indigo-500 hover:shadow-md transition-all"
+                    >
+                      <div class="flex justify-between items-start">
+                        <div class="flex-1">
+                          <h3 class="text-lg font-semibold text-gray-900 mb-1">
+                            <%= event.title %>
+                          </h3>
+                          <%= if event.venue && event.venue.city_ref do %>
+                            <p class="text-sm text-gray-600">
+                              <%= event.venue.city_ref.name %>
+                            </p>
+                          <% end %>
+                        </div>
+                        <div class="text-right ml-4">
+                          <div class="text-sm font-medium text-gray-500">
+                            <%= format_date(event.starts_at) %>
+                          </div>
+                        </div>
+                      </div>
+                    </a>
+                  <% end %>
+
+                  <%= if has_more_past_events?(@past_events, @past_events_page, @past_events_per_page) do %>
+                    <button
+                      phx-click="load_more_past"
+                      class="w-full py-3 px-4 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors font-medium"
+                    >
+                      <%= gettext("Load More") %>
+                    </button>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/eventasaurus_web/live/public_event_show_live.ex
+++ b/lib/eventasaurus_web/live/public_event_show_live.ex
@@ -1001,9 +1001,12 @@ defmodule EventasaurusWeb.PublicEventShowLive do
                     </h2>
                     <div class="flex flex-wrap gap-3">
                       <%= for performer <- @event.performers do %>
-                        <span class="px-4 py-2 bg-gray-100 rounded-lg text-gray-800 font-medium">
+                        <a
+                          href={~p"/performers/#{performer.slug}"}
+                          class="px-4 py-2 bg-gray-100 rounded-lg text-gray-800 font-medium hover:bg-indigo-100 hover:text-indigo-800 transition-colors"
+                        >
                           <%= performer.name %>
-                        </span>
+                        </a>
                       <% end %>
                     </div>
                   </div>

--- a/lib/eventasaurus_web/router.ex
+++ b/lib/eventasaurus_web/router.ex
@@ -386,6 +386,9 @@ defmodule EventasaurusWeb.Router do
       # Direct routes for common auth paths (redirect to proper auth routes)
       get "/login", PageController, :redirect_to_auth_login
       get "/register", PageController, :redirect_to_auth_register
+
+      # Performer profile pages
+      live "/performers/:slug", PerformerLive.Show, :show
     end
   end
 


### PR DESCRIPTION
### TL;DR

Added performer profile pages with event history and statistics.

### What changed?

- Created a new `PerformerLive.Show` LiveView to display performer profiles
- Added new functions to `PerformerStore` to fetch performer data with events
- Created a `CountryFlag` component for displaying country flags
- Fixed the many-to-many relationship in the `Performer` schema by adding explicit join keys
- Updated the public event page to link performer names to their profile pages
- Added a route for `/performers/:slug`
- Improved documentation for the `ArtistEnrichmentJob.enrich_all_pending/0` function

### How to test?

1. Visit any event page and click on a performer's name
2. The performer profile should display with:
   - Basic information (name, country, image)
   - Statistics (total events, first and latest event dates)
   - Upcoming events section
   - Collapsible past events section with pagination
3. Verify that external links (like Resident Advisor) work correctly
4. Test the country flag display for performers with country data

### Why make this change?

This enhances the user experience by providing dedicated performer profile pages where users can see all events associated with a specific performer. It creates a more complete browsing experience, allowing users to discover events through performers they're interested in, and provides historical context about performers' event history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added public performer profile pages showing key info, quick stats, upcoming events, and a collapsible, paginated past events list.
  - Introduced country flag display for performers’ countries with configurable sizes.
- Improvements
  - Event pages now link performer names to their profile pages for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->