### PR TITLE
fixes again

### DIFF
--- a/lib/eventasaurus_discovery/sources/kino_krakow/dedup_handler.ex
+++ b/lib/eventasaurus_discovery/sources/kino_krakow/dedup_handler.ex
@@ -118,7 +118,7 @@ defmodule EventasaurusDiscovery.Sources.KinoKrakow.DedupHandler do
              end
            end) do
         nil ->
-          {:unique, event_data}
+          {:unique, event_data_with_coords}
 
         {match, confidence} ->
           BaseDedupHandler.log_duplicate(source, event_data, match.event, match.source, confidence)

--- a/lib/eventasaurus_discovery/sources/pubquiz/dedup_handler.ex
+++ b/lib/eventasaurus_discovery/sources/pubquiz/dedup_handler.ex
@@ -116,7 +116,7 @@ defmodule EventasaurusDiscovery.Sources.Pubquiz.DedupHandler do
              end
            end) do
         nil ->
-          {:unique, event_data}
+          {:unique, event_data_with_coords}
 
         {match, confidence} ->
           BaseDedupHandler.log_duplicate(source, event_data, match.event, match.source, confidence)


### PR DESCRIPTION
### TL;DR

Fixed a bug in deduplication handlers where events were returning without coordinates.

### What changed?

Fixed a critical bug in both `KinoKrakow` and `Pubquiz` deduplication handlers where the code was returning the original `event_data` instead of `event_data_with_coords` when an event was determined to be unique. This ensures that events properly include their coordinates when passed to subsequent processing steps.

### How to test?

1. Run the event discovery process for either KinoKrakow or Pubquiz sources
2. Verify that unique events (not duplicates) have proper coordinates in the output
3. Check that the events are correctly displayed on the map in the UI

### Why make this change?

Events were missing their coordinates in the final output when they were determined to be unique. This caused issues with location-based features like map display and proximity searches. The fix ensures that the enriched data with coordinates is properly passed through the pipeline.