### PR TITLE
movie fixes

### DIFF
--- a/lib/eventasaurus_discovery/public_events.ex
+++ b/lib/eventasaurus_discovery/public_events.ex
@@ -641,7 +641,7 @@ defmodule EventasaurusDiscovery.PublicEvents do
         |> Enum.reject(&(&1.id == current_event.id))
         |> Enum.shuffle()
         |> Enum.take(display_count)
-        |> Repo.preload([:venue, :categories, :performers, sources: :source])
+        |> Repo.preload([:venue, :categories, :performers, :movies, sources: :source])
 
       _ ->
         []

--- a/lib/eventasaurus_web/json_ld/public_event_schema.ex
+++ b/lib/eventasaurus_web/json_ld/public_event_schema.ex
@@ -469,7 +469,7 @@ defmodule EventasaurusWeb.JsonLd.PublicEventSchema do
     if event.movies && event.movies != [] do
       movie_images =
         event.movies
-        |> Enum.map(fn movie ->
+        |> Enum.map(fn _movie ->
           # TODO: Extract poster URL from movie metadata when available
           # For now, return nil to filter out
           nil
@@ -587,7 +587,7 @@ defmodule EventasaurusWeb.JsonLd.PublicEventSchema do
   end
 
   # Determine if performer is a Person or MusicGroup/Organization
-  defp determine_performer_type(performer) do
+  defp determine_performer_type(_performer) do
     # TODO: Add performer type field to distinguish between person/group
     # For now, default to PerformingGroup which works for both
     "PerformingGroup"

--- a/lib/eventasaurus_web/live/city_live/container_detail_live.ex
+++ b/lib/eventasaurus_web/live/city_live/container_detail_live.ex
@@ -364,12 +364,6 @@ defmodule EventasaurusWeb.CityLive.ContainerDetailLive do
     end
   end
 
-  # Helper to get container type index path (avoids verified sigil warning)
-  defp container_type_index_path(city_slug, container_type) do
-    type_plural = PublicEventContainer.container_type_plural(container_type)
-    "/c/#{city_slug}/#{type_plural}"
-  end
-
   defp format_relative_time(nil), do: "unknown"
 
   defp format_relative_time(%NaiveDateTime{} = naive_datetime) do


### PR DESCRIPTION
### TL;DR

Added movie image support for event displays, prioritizing TMDb posters/backdrops over source images.

### What changed?

- Updated `PublicEvents.get_related_events/2` to preload the `:movies` association
- Enhanced `PublicEventsEnhanced.get_cover_image_url/1` to prioritize movie images from TMDb over source images
- Added similar movie image prioritization to `NearbyEventsComponent.get_event_image_url/1`
- Fixed unused variable warnings in `PublicEventSchema` by replacing variable names with underscores
- Removed unused `container_type_index_path/2` helper function from `ContainerDetailLive`

### How to test?

1. View events that have associated movies
2. Verify that movie posters/backdrops from TMDb are displayed instead of source images
3. Check that events without movie images still fall back to source images correctly
4. Confirm that related events display correctly with movie images where applicable

### Why make this change?

Movie images from TMDb are typically higher quality and more accurate than images scraped from event sources. This change ensures we display the best available imagery for movie events, improving the visual presentation and user experience while maintaining backward compatibility for non-movie events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Event images now prioritize movie backdrops/posters with a robust fallback to source images, improving visuals across nearby events and listings.
  - Public events now include movie data to support richer cover imagery.

- Documentation
  - Updated guidance to reflect new cover image selection behavior.

- Refactor
  - Simplified URL construction for city container detail pages.
  - Minor internal cleanups in structured data handling and image selection logic to reduce unused code without altering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->